### PR TITLE
💄 style: fix markdown linting in changelog command

### DIFF
--- a/.claude/commands/changelog.md
+++ b/.claude/commands/changelog.md
@@ -10,7 +10,8 @@ description: Maintains a CHANGELOG.md document in this repository
 ## Usage
 
 - `changelog --create` - Create new CHANGELOG.md
-- `changelog --add-entry "description" --type [added|changed|deprecated|removed|fixed|security]` - Add new entry
+- `changelog --add-entry "description" --type TYPE` - Add new entry
+  - Types: `added`, `changed`, `deprecated`, `removed`, `fixed`, `security`
 - `changelog --release X.Y.Z` - Move unreleased items to new version
 
 ## Instructions


### PR DESCRIPTION
# Summary

Fixes markdown linting violation in the changelog command by improving the documentation layout and readability. Resolves MD013/line-length error while enhancing the overall structure of the usage documentation.

## Changes

- **Fixed MD013/line-length violation** in `.claude/commands/changelog.md` line 13
- **Restructured command usage documentation** to improve readability:
  - Shortened main command line from long bracket notation to `--type TYPE`
  - Added clear sub-bullet listing all available changelog entry types
  - Maintained all functionality information in a more organized format
- **Enhanced documentation clarity** while staying under 100-character line limit

## Testing

- Verified markdown linting passes with `markdownlint .claude/commands/changelog.md`
- Confirmed all changelog entry types are properly documented
- Layout improvement maintains functionality while enhancing readability
- No breaking changes to command functionality or interface

## Checklist

- [x] Code follows project conventions
- [x] Tests pass locally
- [x] Documentation updated if needed
- [x] Ready for review