### PR TITLE
feat: add handler tests

### DIFF
--- a/apps/prompt_manager/internal/api/handlers/prompt_handler.go
+++ b/apps/prompt_manager/internal/api/handlers/prompt_handler.go
@@ -18,21 +18,6 @@ func NewPromptHandler(db *database.DB) *PromptHandler {
 	return &PromptHandler{db: db}
 }
 
-// HookData represents the structure of hook data from Claude Code
-type HookData struct {
-	Event     string                 `json:"event"`
-	Timestamp string                 `json:"timestamp"`
-	SessionID string                 `json:"session_id"`
-	Filename  string                 `json:"filename"`
-	Data      map[string]interface{} `json:"data"`
-}
-
-// APIResponse represents a standard API response
-type APIResponse struct {
-	Success bool        `json:"success"`
-	Data    interface{} `json:"data,omitempty"`
-	Error   *string     `json:"error,omitempty"`
-}
 
 // HandlePromptSubmit processes user prompt submissions
 func (ph *PromptHandler) HandlePromptSubmit(w http.ResponseWriter, r *http.Request) {

--- a/apps/prompt_manager/internal/api/handlers/prompt_handler_test.go
+++ b/apps/prompt_manager/internal/api/handlers/prompt_handler_test.go
@@ -1,0 +1,373 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/claude-code-template/prompt-manager/internal/database"
+)
+
+func setupTestDB(t *testing.T) *database.DB {
+	// Create temporary database file
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+	
+	config := &database.Config{
+		DatabasePath:  dbPath,
+		MigrationsDir: "../../../database/migrations",
+	}
+	
+	db, err := database.New(config)
+	if err != nil {
+		t.Fatalf("Failed to create test database: %v", err)
+	}
+	
+	// Run migrations
+	if err := db.RunMigrations(config.MigrationsDir); err != nil {
+		t.Fatalf("Failed to run migrations: %v", err)
+	}
+	
+	return db
+}
+
+func TestNewPromptHandler(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	
+	handler := NewPromptHandler(db)
+	
+	if handler == nil {
+		t.Fatal("Expected handler to be created, got nil")
+	}
+	
+	if handler.db != db {
+		t.Error("Expected handler to store database reference")
+	}
+}
+
+func TestPromptHandler_HandlePromptSubmit_Success(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	
+	handler := NewPromptHandler(db)
+	
+	// Create test payload
+	hookData := HookData{
+		Event:     "UserPromptSubmit",
+		Timestamp: time.Now().Format(time.RFC3339),
+		SessionID: "test-session-123",
+		Filename:  "activity-monitor",
+		Data: map[string]interface{}{
+			"prompt": "Test prompt content",
+			"cwd":    "/test/directory",
+		},
+	}
+	
+	payload, err := json.Marshal(hookData)
+	if err != nil {
+		t.Fatalf("Failed to marshal test data: %v", err)
+	}
+	
+	// Create request
+	req := httptest.NewRequest(http.MethodPost, "/messages/prompt", bytes.NewBuffer(payload))
+	req.Header.Set("Content-Type", "application/json")
+	
+	// Create response recorder
+	w := httptest.NewRecorder()
+	
+	// Execute request
+	handler.HandlePromptSubmit(w, req)
+	
+	// Check response
+	if w.Code != http.StatusCreated {
+		t.Errorf("Expected status %d, got %d", http.StatusCreated, w.Code)
+	}
+	
+	// Parse response
+	var response APIResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	
+	if !response.Success {
+		t.Error("Expected response.Success to be true")
+	}
+	
+	if response.Error != nil {
+		t.Errorf("Expected no error, got %s", *response.Error)
+	}
+	
+	// Verify data structure
+	data, ok := response.Data.(map[string]interface{})
+	if !ok {
+		t.Fatal("Expected response.Data to be a map")
+	}
+	
+	if data["session_id"] != hookData.SessionID {
+		t.Errorf("Expected session_id %s, got %v", hookData.SessionID, data["session_id"])
+	}
+	
+	if data["type"] != "prompt" {
+		t.Errorf("Expected type 'prompt', got %v", data["type"])
+	}
+}
+
+func TestPromptHandler_HandlePromptSubmit_MethodNotAllowed(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	
+	handler := NewPromptHandler(db)
+	
+	// Test GET request (not allowed)
+	req := httptest.NewRequest(http.MethodGet, "/messages/prompt", nil)
+	w := httptest.NewRecorder()
+	
+	handler.HandlePromptSubmit(w, req)
+	
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("Expected status %d, got %d", http.StatusMethodNotAllowed, w.Code)
+	}
+	
+	var response APIResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	
+	if response.Success {
+		t.Error("Expected response.Success to be false")
+	}
+	
+	if response.Error == nil || *response.Error != "Method not allowed" {
+		t.Error("Expected 'Method not allowed' error")
+	}
+}
+
+func TestPromptHandler_HandlePromptSubmit_InvalidJSON(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	
+	handler := NewPromptHandler(db)
+	
+	// Create request with invalid JSON
+	req := httptest.NewRequest(http.MethodPost, "/messages/prompt", bytes.NewBufferString("invalid json"))
+	req.Header.Set("Content-Type", "application/json")
+	
+	w := httptest.NewRecorder()
+	handler.HandlePromptSubmit(w, req)
+	
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+	
+	var response APIResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	
+	if response.Success {
+		t.Error("Expected response.Success to be false")
+	}
+	
+	if response.Error == nil || *response.Error != "Invalid JSON request body" {
+		t.Error("Expected 'Invalid JSON request body' error")
+	}
+}
+
+func TestPromptHandler_HandlePromptSubmit_MissingSessionID(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	
+	handler := NewPromptHandler(db)
+	
+	// Create payload without session_id
+	hookData := HookData{
+		Event:     "UserPromptSubmit",
+		Timestamp: time.Now().Format(time.RFC3339),
+		// SessionID missing
+		Filename: "activity-monitor",
+		Data: map[string]interface{}{
+			"prompt": "Test prompt content",
+		},
+	}
+	
+	payload, _ := json.Marshal(hookData)
+	
+	req := httptest.NewRequest(http.MethodPost, "/messages/prompt", bytes.NewBuffer(payload))
+	req.Header.Set("Content-Type", "application/json")
+	
+	w := httptest.NewRecorder()
+	handler.HandlePromptSubmit(w, req)
+	
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+	
+	var response APIResponse
+	json.NewDecoder(w.Body).Decode(&response)
+	
+	if response.Success {
+		t.Error("Expected response.Success to be false")
+	}
+	
+	if response.Error == nil || *response.Error != "session_id is required" {
+		t.Error("Expected 'session_id is required' error")
+	}
+}
+
+func TestPromptHandler_HandlePromptSubmit_MissingPromptData(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	
+	handler := NewPromptHandler(db)
+	
+	// Create payload without prompt data
+	hookData := HookData{
+		Event:     "UserPromptSubmit",
+		Timestamp: time.Now().Format(time.RFC3339),
+		SessionID: "test-session-123",
+		Filename:  "activity-monitor",
+		Data:      map[string]interface{}{
+			// prompt missing
+			"cwd": "/test/directory",
+		},
+	}
+	
+	payload, _ := json.Marshal(hookData)
+	
+	req := httptest.NewRequest(http.MethodPost, "/messages/prompt", bytes.NewBuffer(payload))
+	req.Header.Set("Content-Type", "application/json")
+	
+	w := httptest.NewRecorder()
+	handler.HandlePromptSubmit(w, req)
+	
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+	
+	var response APIResponse
+	json.NewDecoder(w.Body).Decode(&response)
+	
+	if response.Success {
+		t.Error("Expected response.Success to be false")
+	}
+	
+	if response.Error == nil || *response.Error != "no prompt data in request" {
+		t.Error("Expected 'no prompt data in request' error")
+	}
+}
+
+func TestPromptHandler_HandlePromptSubmit_InvalidPromptDataType(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	
+	handler := NewPromptHandler(db)
+	
+	// Create payload with non-string prompt data
+	hookData := HookData{
+		Event:     "UserPromptSubmit",
+		Timestamp: time.Now().Format(time.RFC3339),
+		SessionID: "test-session-123",
+		Filename:  "activity-monitor",
+		Data: map[string]interface{}{
+			"prompt": 123, // Should be string, not number
+		},
+	}
+	
+	payload, _ := json.Marshal(hookData)
+	
+	req := httptest.NewRequest(http.MethodPost, "/messages/prompt", bytes.NewBuffer(payload))
+	req.Header.Set("Content-Type", "application/json")
+	
+	w := httptest.NewRecorder()
+	handler.HandlePromptSubmit(w, req)
+	
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+	
+	var response APIResponse
+	json.NewDecoder(w.Body).Decode(&response)
+	
+	if response.Success {
+		t.Error("Expected response.Success to be false")
+	}
+	
+	if response.Error == nil || *response.Error != "prompt data must be a string" {
+		t.Error("Expected 'prompt data must be a string' error")
+	}
+}
+
+func TestPromptHandler_CreateConversationAndMessage(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	
+	handler := NewPromptHandler(db)
+	
+	// Submit first prompt for new session
+	hookData1 := HookData{
+		Event:     "UserPromptSubmit",
+		Timestamp: time.Now().Format(time.RFC3339),
+		SessionID: "test-session-456",
+		Filename:  "activity-monitor",
+		Data: map[string]interface{}{
+			"prompt":          "First prompt",
+			"cwd":             "/test/directory",
+			"transcript_path": "/test/transcript.md",
+		},
+	}
+	
+	payload1, _ := json.Marshal(hookData1)
+	req1 := httptest.NewRequest(http.MethodPost, "/messages/prompt", bytes.NewBuffer(payload1))
+	req1.Header.Set("Content-Type", "application/json")
+	
+	w1 := httptest.NewRecorder()
+	handler.HandlePromptSubmit(w1, req1)
+	
+	if w1.Code != http.StatusCreated {
+		t.Fatalf("First request failed with status %d", w1.Code)
+	}
+	
+	var response1 APIResponse
+	json.NewDecoder(w1.Body).Decode(&response1)
+	
+	data1 := response1.Data.(map[string]interface{})
+	conversationID1 := data1["conversation_id"]
+	
+	// Submit second prompt for same session
+	hookData2 := HookData{
+		Event:     "UserPromptSubmit",
+		Timestamp: time.Now().Format(time.RFC3339),
+		SessionID: "test-session-456", // Same session
+		Filename:  "activity-monitor",
+		Data: map[string]interface{}{
+			"prompt": "Second prompt",
+		},
+	}
+	
+	payload2, _ := json.Marshal(hookData2)
+	req2 := httptest.NewRequest(http.MethodPost, "/messages/prompt", bytes.NewBuffer(payload2))
+	req2.Header.Set("Content-Type", "application/json")
+	
+	w2 := httptest.NewRecorder()
+	handler.HandlePromptSubmit(w2, req2)
+	
+	if w2.Code != http.StatusCreated {
+		t.Fatalf("Second request failed with status %d", w2.Code)
+	}
+	
+	var response2 APIResponse
+	json.NewDecoder(w2.Body).Decode(&response2)
+	
+	data2 := response2.Data.(map[string]interface{})
+	conversationID2 := data2["conversation_id"]
+	
+	// Should use same conversation for same session
+	if conversationID1 != conversationID2 {
+		t.Errorf("Expected same conversation ID for same session, got %v and %v", conversationID1, conversationID2)
+	}
+}

--- a/apps/prompt_manager/internal/api/handlers/prompt_handler_test.go
+++ b/apps/prompt_manager/internal/api/handlers/prompt_handler_test.go
@@ -50,269 +50,195 @@ func TestNewPromptHandler(t *testing.T) {
 	}
 }
 
-func TestPromptHandler_HandlePromptSubmit_Success(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	
-	handler := NewPromptHandler(db)
-	
-	// Create test payload
-	hookData := HookData{
-		Event:     "UserPromptSubmit",
-		Timestamp: time.Now().Format(time.RFC3339),
-		SessionID: "test-session-123",
-		Filename:  "activity-monitor",
-		Data: map[string]interface{}{
-			"prompt": "Test prompt content",
-			"cwd":    "/test/directory",
+func TestPromptHandler_HandlePromptSubmit(t *testing.T) {
+	tests := []struct {
+		name           string
+		method         string
+		payload        interface{}
+		expectedStatus int
+		expectedError  string
+		expectSuccess  bool
+		validateData   func(t *testing.T, data map[string]interface{})
+	}{
+		{
+			name:           "successful prompt submission",
+			method:         http.MethodPost,
+			payload: HookData{
+				Event:     "UserPromptSubmit",
+				Timestamp: time.Now().Format(time.RFC3339),
+				SessionID: "test-session-123",
+				Filename:  "activity-monitor",
+				Data: map[string]interface{}{
+					"prompt": "Test prompt content",
+					"cwd":    "/test/directory",
+				},
+			},
+			expectedStatus: http.StatusCreated,
+			expectSuccess:  true,
+			validateData: func(t *testing.T, data map[string]interface{}) {
+				if data["session_id"] != "test-session-123" {
+					t.Errorf("Expected session_id 'test-session-123', got %v", data["session_id"])
+				}
+				if data["type"] != "prompt" {
+					t.Errorf("Expected type 'prompt', got %v", data["type"])
+				}
+				if data["message_id"] == nil {
+					t.Error("Expected message_id to be set")
+				}
+				if data["conversation_id"] == nil {
+					t.Error("Expected conversation_id to be set")
+				}
+			},
+		},
+		{
+			name:           "method not allowed",
+			method:         http.MethodGet,
+			payload:        nil,
+			expectedStatus: http.StatusMethodNotAllowed,
+			expectedError:  "Method not allowed",
+			expectSuccess:  false,
+		},
+		{
+			name:           "invalid JSON",
+			method:         http.MethodPost,
+			payload:        "invalid json",
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "Invalid JSON request body",
+			expectSuccess:  false,
+		},
+		{
+			name:   "missing session ID",
+			method: http.MethodPost,
+			payload: HookData{
+				Event:     "UserPromptSubmit",
+				Timestamp: time.Now().Format(time.RFC3339),
+				// SessionID missing
+				Filename: "activity-monitor",
+				Data: map[string]interface{}{
+					"prompt": "Test prompt content",
+				},
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "session_id is required",
+			expectSuccess:  false,
+		},
+		{
+			name:   "missing prompt data",
+			method: http.MethodPost,
+			payload: HookData{
+				Event:     "UserPromptSubmit",
+				Timestamp: time.Now().Format(time.RFC3339),
+				SessionID: "test-session-123",
+				Filename:  "activity-monitor",
+				Data: map[string]interface{}{
+					// prompt missing
+					"cwd": "/test/directory",
+				},
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "no prompt data in request",
+			expectSuccess:  false,
+		},
+		{
+			name:   "invalid prompt data type",
+			method: http.MethodPost,
+			payload: HookData{
+				Event:     "UserPromptSubmit",
+				Timestamp: time.Now().Format(time.RFC3339),
+				SessionID: "test-session-123",
+				Filename:  "activity-monitor",
+				Data: map[string]interface{}{
+					"prompt": 123, // Should be string, not number
+				},
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "prompt data must be a string",
+			expectSuccess:  false,
 		},
 	}
-	
-	payload, err := json.Marshal(hookData)
-	if err != nil {
-		t.Fatalf("Failed to marshal test data: %v", err)
-	}
-	
-	// Create request
-	req := httptest.NewRequest(http.MethodPost, "/messages/prompt", bytes.NewBuffer(payload))
-	req.Header.Set("Content-Type", "application/json")
-	
-	// Create response recorder
-	w := httptest.NewRecorder()
-	
-	// Execute request
-	handler.HandlePromptSubmit(w, req)
-	
-	// Check response
-	if w.Code != http.StatusCreated {
-		t.Errorf("Expected status %d, got %d", http.StatusCreated, w.Code)
-	}
-	
-	// Parse response
-	var response APIResponse
-	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
-		t.Fatalf("Failed to decode response: %v", err)
-	}
-	
-	if !response.Success {
-		t.Error("Expected response.Success to be true")
-	}
-	
-	if response.Error != nil {
-		t.Errorf("Expected no error, got %s", *response.Error)
-	}
-	
-	// Verify data structure
-	data, ok := response.Data.(map[string]interface{})
-	if !ok {
-		t.Fatal("Expected response.Data to be a map")
-	}
-	
-	if data["session_id"] != hookData.SessionID {
-		t.Errorf("Expected session_id %s, got %v", hookData.SessionID, data["session_id"])
-	}
-	
-	if data["type"] != "prompt" {
-		t.Errorf("Expected type 'prompt', got %v", data["type"])
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := setupTestDB(t)
+			defer db.Close()
+			
+			handler := NewPromptHandler(db)
+			
+			// Prepare request
+			var req *http.Request
+			if tt.payload == nil {
+				req = httptest.NewRequest(tt.method, "/messages/prompt", nil)
+			} else if str, ok := tt.payload.(string); ok {
+				// Handle string payload (invalid JSON case)
+				req = httptest.NewRequest(tt.method, "/messages/prompt", bytes.NewBufferString(str))
+			} else {
+				// Handle struct payload
+				payload, err := json.Marshal(tt.payload)
+				if err != nil {
+					t.Fatalf("Failed to marshal test payload: %v", err)
+				}
+				req = httptest.NewRequest(tt.method, "/messages/prompt", bytes.NewBuffer(payload))
+			}
+			
+			if tt.method == http.MethodPost {
+				req.Header.Set("Content-Type", "application/json")
+			}
+			
+			// Execute request
+			w := httptest.NewRecorder()
+			handler.HandlePromptSubmit(w, req)
+			
+			// Check status code
+			if w.Code != tt.expectedStatus {
+				t.Errorf("Expected status %d, got %d", tt.expectedStatus, w.Code)
+			}
+			
+			// Parse response
+			var response APIResponse
+			if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+				t.Fatalf("Failed to decode response: %v", err)
+			}
+			
+			// Check success flag
+			if response.Success != tt.expectSuccess {
+				t.Errorf("Expected success %v, got %v", tt.expectSuccess, response.Success)
+			}
+			
+			// Check error message
+			if tt.expectedError != "" {
+				if response.Error == nil {
+					t.Errorf("Expected error '%s', got nil", tt.expectedError)
+				} else if *response.Error != tt.expectedError {
+					t.Errorf("Expected error '%s', got '%s'", tt.expectedError, *response.Error)
+				}
+			} else if response.Error != nil {
+				t.Errorf("Expected no error, got '%s'", *response.Error)
+			}
+			
+			// Custom data validation
+			if tt.validateData != nil && response.Success {
+				data, ok := response.Data.(map[string]interface{})
+				if !ok {
+					t.Fatal("Expected response.Data to be a map")
+				}
+				tt.validateData(t, data)
+			}
+		})
 	}
 }
 
-func TestPromptHandler_HandlePromptSubmit_MethodNotAllowed(t *testing.T) {
+func TestPromptHandler_ConversationReuse(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
 	
 	handler := NewPromptHandler(db)
+	sessionID := "test-session-reuse-456"
 	
-	// Test GET request (not allowed)
-	req := httptest.NewRequest(http.MethodGet, "/messages/prompt", nil)
-	w := httptest.NewRecorder()
-	
-	handler.HandlePromptSubmit(w, req)
-	
-	if w.Code != http.StatusMethodNotAllowed {
-		t.Errorf("Expected status %d, got %d", http.StatusMethodNotAllowed, w.Code)
-	}
-	
-	var response APIResponse
-	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
-		t.Fatalf("Failed to decode response: %v", err)
-	}
-	
-	if response.Success {
-		t.Error("Expected response.Success to be false")
-	}
-	
-	if response.Error == nil || *response.Error != "Method not allowed" {
-		t.Error("Expected 'Method not allowed' error")
-	}
-}
-
-func TestPromptHandler_HandlePromptSubmit_InvalidJSON(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	
-	handler := NewPromptHandler(db)
-	
-	// Create request with invalid JSON
-	req := httptest.NewRequest(http.MethodPost, "/messages/prompt", bytes.NewBufferString("invalid json"))
-	req.Header.Set("Content-Type", "application/json")
-	
-	w := httptest.NewRecorder()
-	handler.HandlePromptSubmit(w, req)
-	
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("Expected status %d, got %d", http.StatusBadRequest, w.Code)
-	}
-	
-	var response APIResponse
-	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
-		t.Fatalf("Failed to decode response: %v", err)
-	}
-	
-	if response.Success {
-		t.Error("Expected response.Success to be false")
-	}
-	
-	if response.Error == nil || *response.Error != "Invalid JSON request body" {
-		t.Error("Expected 'Invalid JSON request body' error")
-	}
-}
-
-func TestPromptHandler_HandlePromptSubmit_MissingSessionID(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	
-	handler := NewPromptHandler(db)
-	
-	// Create payload without session_id
-	hookData := HookData{
-		Event:     "UserPromptSubmit",
-		Timestamp: time.Now().Format(time.RFC3339),
-		// SessionID missing
-		Filename: "activity-monitor",
-		Data: map[string]interface{}{
-			"prompt": "Test prompt content",
-		},
-	}
-	
-	payload, _ := json.Marshal(hookData)
-	
-	req := httptest.NewRequest(http.MethodPost, "/messages/prompt", bytes.NewBuffer(payload))
-	req.Header.Set("Content-Type", "application/json")
-	
-	w := httptest.NewRecorder()
-	handler.HandlePromptSubmit(w, req)
-	
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("Expected status %d, got %d", http.StatusBadRequest, w.Code)
-	}
-	
-	var response APIResponse
-	json.NewDecoder(w.Body).Decode(&response)
-	
-	if response.Success {
-		t.Error("Expected response.Success to be false")
-	}
-	
-	if response.Error == nil || *response.Error != "session_id is required" {
-		t.Error("Expected 'session_id is required' error")
-	}
-}
-
-func TestPromptHandler_HandlePromptSubmit_MissingPromptData(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	
-	handler := NewPromptHandler(db)
-	
-	// Create payload without prompt data
-	hookData := HookData{
-		Event:     "UserPromptSubmit",
-		Timestamp: time.Now().Format(time.RFC3339),
-		SessionID: "test-session-123",
-		Filename:  "activity-monitor",
-		Data:      map[string]interface{}{
-			// prompt missing
-			"cwd": "/test/directory",
-		},
-	}
-	
-	payload, _ := json.Marshal(hookData)
-	
-	req := httptest.NewRequest(http.MethodPost, "/messages/prompt", bytes.NewBuffer(payload))
-	req.Header.Set("Content-Type", "application/json")
-	
-	w := httptest.NewRecorder()
-	handler.HandlePromptSubmit(w, req)
-	
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("Expected status %d, got %d", http.StatusBadRequest, w.Code)
-	}
-	
-	var response APIResponse
-	json.NewDecoder(w.Body).Decode(&response)
-	
-	if response.Success {
-		t.Error("Expected response.Success to be false")
-	}
-	
-	if response.Error == nil || *response.Error != "no prompt data in request" {
-		t.Error("Expected 'no prompt data in request' error")
-	}
-}
-
-func TestPromptHandler_HandlePromptSubmit_InvalidPromptDataType(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	
-	handler := NewPromptHandler(db)
-	
-	// Create payload with non-string prompt data
-	hookData := HookData{
-		Event:     "UserPromptSubmit",
-		Timestamp: time.Now().Format(time.RFC3339),
-		SessionID: "test-session-123",
-		Filename:  "activity-monitor",
-		Data: map[string]interface{}{
-			"prompt": 123, // Should be string, not number
-		},
-	}
-	
-	payload, _ := json.Marshal(hookData)
-	
-	req := httptest.NewRequest(http.MethodPost, "/messages/prompt", bytes.NewBuffer(payload))
-	req.Header.Set("Content-Type", "application/json")
-	
-	w := httptest.NewRecorder()
-	handler.HandlePromptSubmit(w, req)
-	
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("Expected status %d, got %d", http.StatusBadRequest, w.Code)
-	}
-	
-	var response APIResponse
-	json.NewDecoder(w.Body).Decode(&response)
-	
-	if response.Success {
-		t.Error("Expected response.Success to be false")
-	}
-	
-	if response.Error == nil || *response.Error != "prompt data must be a string" {
-		t.Error("Expected 'prompt data must be a string' error")
-	}
-}
-
-func TestPromptHandler_CreateConversationAndMessage(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	
-	handler := NewPromptHandler(db)
-	
-	// Submit first prompt for new session
+	// Submit first prompt
 	hookData1 := HookData{
 		Event:     "UserPromptSubmit",
 		Timestamp: time.Now().Format(time.RFC3339),
-		SessionID: "test-session-456",
+		SessionID: sessionID,
 		Filename:  "activity-monitor",
 		Data: map[string]interface{}{
 			"prompt":          "First prompt",
@@ -334,7 +260,6 @@ func TestPromptHandler_CreateConversationAndMessage(t *testing.T) {
 	
 	var response1 APIResponse
 	json.NewDecoder(w1.Body).Decode(&response1)
-	
 	data1 := response1.Data.(map[string]interface{})
 	conversationID1 := data1["conversation_id"]
 	
@@ -342,7 +267,7 @@ func TestPromptHandler_CreateConversationAndMessage(t *testing.T) {
 	hookData2 := HookData{
 		Event:     "UserPromptSubmit",
 		Timestamp: time.Now().Format(time.RFC3339),
-		SessionID: "test-session-456", // Same session
+		SessionID: sessionID, // Same session
 		Filename:  "activity-monitor",
 		Data: map[string]interface{}{
 			"prompt": "Second prompt",
@@ -362,7 +287,6 @@ func TestPromptHandler_CreateConversationAndMessage(t *testing.T) {
 	
 	var response2 APIResponse
 	json.NewDecoder(w2.Body).Decode(&response2)
-	
 	data2 := response2.Data.(map[string]interface{})
 	conversationID2 := data2["conversation_id"]
 	

--- a/apps/prompt_manager/internal/api/handlers/prompt_handler_test.go
+++ b/apps/prompt_manager/internal/api/handlers/prompt_handler_test.go
@@ -5,35 +5,10 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
 	"testing"
 	"time"
-
-	"github.com/claude-code-template/prompt-manager/internal/database"
 )
 
-func setupTestDB(t *testing.T) *database.DB {
-	// Create temporary database file
-	tmpDir := t.TempDir()
-	dbPath := filepath.Join(tmpDir, "test.db")
-	
-	config := &database.Config{
-		DatabasePath:  dbPath,
-		MigrationsDir: "../../../database/migrations",
-	}
-	
-	db, err := database.New(config)
-	if err != nil {
-		t.Fatalf("Failed to create test database: %v", err)
-	}
-	
-	// Run migrations
-	if err := db.RunMigrations(config.MigrationsDir); err != nil {
-		t.Fatalf("Failed to run migrations: %v", err)
-	}
-	
-	return db
-}
 
 func TestNewPromptHandler(t *testing.T) {
 	db := setupTestDB(t)
@@ -159,6 +134,8 @@ func TestPromptHandler_HandlePromptSubmit(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			
 			db := setupTestDB(t)
 			defer db.Close()
 			

--- a/apps/prompt_manager/internal/api/handlers/response_handler_test.go
+++ b/apps/prompt_manager/internal/api/handlers/response_handler_test.go
@@ -24,301 +24,226 @@ func TestNewResponseHandler(t *testing.T) {
 	}
 }
 
-func TestResponseHandler_HandleResponseSubmit_Success(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	
-	handler := NewResponseHandler(db)
-	
-	// Create test payload
-	hookData := HookData{
-		Event:     "PostToolUse",
-		Timestamp: time.Now().Format(time.RFC3339),
-		SessionID: "test-session-456",
-		Filename:  "activity-monitor",
-		Data: map[string]interface{}{
-			"response": "This is an assistant response",
-			"tool_calls": []map[string]interface{}{
-				{
-					"name":      "Read",
-					"arguments": map[string]interface{}{"file_path": "/test/file.txt"},
+func TestResponseHandler_HandleResponseSubmit(t *testing.T) {
+	tests := []struct {
+		name           string
+		method         string
+		payload        interface{}
+		expectedStatus int
+		expectedError  string
+		expectSuccess  bool
+		validateData   func(t *testing.T, data map[string]interface{})
+	}{
+		{
+			name:   "successful response submission",
+			method: http.MethodPost,
+			payload: HookData{
+				Event:     "PostToolUse",
+				Timestamp: time.Now().Format(time.RFC3339),
+				SessionID: "test-session-456",
+				Filename:  "activity-monitor",
+				Data: map[string]interface{}{
+					"response": "This is an assistant response",
+					"tool_calls": []map[string]interface{}{
+						{
+							"name":      "Read",
+							"arguments": map[string]interface{}{"file_path": "/test/file.txt"},
+						},
+					},
+					"execution_time": 1500,
 				},
 			},
-			"execution_time": 1500, // milliseconds
+			expectedStatus: http.StatusCreated,
+			expectSuccess:  true,
+			validateData: func(t *testing.T, data map[string]interface{}) {
+				if data["session_id"] != "test-session-456" {
+					t.Errorf("Expected session_id 'test-session-456', got %v", data["session_id"])
+				}
+				if data["type"] != "response" {
+					t.Errorf("Expected type 'response', got %v", data["type"])
+				}
+				if data["message_id"] == nil {
+					t.Error("Expected message_id to be set")
+				}
+				if data["conversation_id"] == nil {
+					t.Error("Expected conversation_id to be set")
+				}
+			},
 		},
-	}
-	
-	payload, err := json.Marshal(hookData)
-	if err != nil {
-		t.Fatalf("Failed to marshal test data: %v", err)
-	}
-	
-	// Create request
-	req := httptest.NewRequest(http.MethodPost, "/messages/response", bytes.NewBuffer(payload))
-	req.Header.Set("Content-Type", "application/json")
-	
-	// Create response recorder
-	w := httptest.NewRecorder()
-	
-	// Execute request
-	handler.HandleResponseSubmit(w, req)
-	
-	// Check response
-	if w.Code != http.StatusCreated {
-		t.Errorf("Expected status %d, got %d", http.StatusCreated, w.Code)
-	}
-	
-	// Parse response
-	var response APIResponse
-	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
-		t.Fatalf("Failed to decode response: %v", err)
-	}
-	
-	if !response.Success {
-		t.Error("Expected response.Success to be true")
-	}
-	
-	if response.Error != nil {
-		t.Errorf("Expected no error, got %s", *response.Error)
-	}
-	
-	// Verify data structure
-	data, ok := response.Data.(map[string]interface{})
-	if !ok {
-		t.Fatal("Expected response.Data to be a map")
-	}
-	
-	if data["session_id"] != hookData.SessionID {
-		t.Errorf("Expected session_id %s, got %v", hookData.SessionID, data["session_id"])
-	}
-	
-	if data["type"] != "response" {
-		t.Errorf("Expected type 'response', got %v", data["type"])
-	}
-}
-
-func TestResponseHandler_HandleResponseSubmit_MethodNotAllowed(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	
-	handler := NewResponseHandler(db)
-	
-	// Test GET request (not allowed)
-	req := httptest.NewRequest(http.MethodGet, "/messages/response", nil)
-	w := httptest.NewRecorder()
-	
-	handler.HandleResponseSubmit(w, req)
-	
-	if w.Code != http.StatusMethodNotAllowed {
-		t.Errorf("Expected status %d, got %d", http.StatusMethodNotAllowed, w.Code)
-	}
-	
-	var response APIResponse
-	json.NewDecoder(w.Body).Decode(&response)
-	
-	if response.Success {
-		t.Error("Expected response.Success to be false")
-	}
-	
-	if response.Error == nil || *response.Error != "Method not allowed" {
-		t.Error("Expected 'Method not allowed' error")
-	}
-}
-
-func TestResponseHandler_HandleResponseSubmit_InvalidJSON(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	
-	handler := NewResponseHandler(db)
-	
-	// Create request with invalid JSON
-	req := httptest.NewRequest(http.MethodPost, "/messages/response", bytes.NewBufferString("invalid json"))
-	req.Header.Set("Content-Type", "application/json")
-	
-	w := httptest.NewRecorder()
-	handler.HandleResponseSubmit(w, req)
-	
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("Expected status %d, got %d", http.StatusBadRequest, w.Code)
-	}
-	
-	var response APIResponse
-	json.NewDecoder(w.Body).Decode(&response)
-	
-	if response.Success {
-		t.Error("Expected response.Success to be false")
-	}
-}
-
-func TestResponseHandler_HandleResponseSubmit_MissingSessionID(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	
-	handler := NewResponseHandler(db)
-	
-	// Create payload without session_id
-	hookData := HookData{
-		Event:     "PostToolUse",
-		Timestamp: time.Now().Format(time.RFC3339),
-		// SessionID missing
-		Filename: "activity-monitor",
-		Data: map[string]interface{}{
-			"response": "Test response content",
+		{
+			name:           "method not allowed",
+			method:         http.MethodGet,
+			payload:        nil,
+			expectedStatus: http.StatusMethodNotAllowed,
+			expectedError:  "Method not allowed",
+			expectSuccess:  false,
 		},
-	}
-	
-	payload, _ := json.Marshal(hookData)
-	
-	req := httptest.NewRequest(http.MethodPost, "/messages/response", bytes.NewBuffer(payload))
-	req.Header.Set("Content-Type", "application/json")
-	
-	w := httptest.NewRecorder()
-	handler.HandleResponseSubmit(w, req)
-	
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("Expected status %d, got %d", http.StatusBadRequest, w.Code)
-	}
-	
-	var response APIResponse
-	json.NewDecoder(w.Body).Decode(&response)
-	
-	if response.Success {
-		t.Error("Expected response.Success to be false")
-	}
-}
-
-func TestResponseHandler_HandleResponseSubmit_MissingResponseData(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	
-	handler := NewResponseHandler(db)
-	
-	// Create payload without response data
-	hookData := HookData{
-		Event:     "PostToolUse",
-		Timestamp: time.Now().Format(time.RFC3339),
-		SessionID: "test-session-123",
-		Filename:  "activity-monitor",
-		Data: map[string]interface{}{
-			// response missing
-			"tool_calls": []interface{}{},
+		{
+			name:           "invalid JSON",
+			method:         http.MethodPost,
+			payload:        "invalid json",
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "Invalid JSON request body",
+			expectSuccess:  false,
 		},
-	}
-	
-	payload, _ := json.Marshal(hookData)
-	
-	req := httptest.NewRequest(http.MethodPost, "/messages/response", bytes.NewBuffer(payload))
-	req.Header.Set("Content-Type", "application/json")
-	
-	w := httptest.NewRecorder()
-	handler.HandleResponseSubmit(w, req)
-	
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("Expected status %d, got %d", http.StatusBadRequest, w.Code)
-	}
-	
-	var response APIResponse
-	json.NewDecoder(w.Body).Decode(&response)
-	
-	if response.Success {
-		t.Error("Expected response.Success to be false")
-	}
-}
-
-func TestResponseHandler_HandleResponseSubmit_InvalidResponseDataType(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	
-	handler := NewResponseHandler(db)
-	
-	// Create payload with non-string response data
-	hookData := HookData{
-		Event:     "PostToolUse",
-		Timestamp: time.Now().Format(time.RFC3339),
-		SessionID: "test-session-123",
-		Filename:  "activity-monitor",
-		Data: map[string]interface{}{
-			"response": 456, // Should be string, not number
-		},
-	}
-	
-	payload, _ := json.Marshal(hookData)
-	
-	req := httptest.NewRequest(http.MethodPost, "/messages/response", bytes.NewBuffer(payload))
-	req.Header.Set("Content-Type", "application/json")
-	
-	w := httptest.NewRecorder()
-	handler.HandleResponseSubmit(w, req)
-	
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("Expected status %d, got %d", http.StatusBadRequest, w.Code)
-	}
-	
-	var response APIResponse
-	json.NewDecoder(w.Body).Decode(&response)
-	
-	if response.Success {
-		t.Error("Expected response.Success to be false")
-	}
-}
-
-func TestResponseHandler_HandleResponseSubmit_WithToolCalls(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	
-	handler := NewResponseHandler(db)
-	
-	// Create test payload with tool calls
-	hookData := HookData{
-		Event:     "PostToolUse",
-		Timestamp: time.Now().Format(time.RFC3339),
-		SessionID: "test-session-789",
-		Filename:  "activity-monitor",
-		Data: map[string]interface{}{
-			"response": "Used Read tool to check file contents",
-			"tool_calls": []map[string]interface{}{
-				{
-					"name": "Read",
-					"arguments": map[string]interface{}{
-						"file_path": "/test/example.txt",
-						"limit":     100,
-					},
-				},
-				{
-					"name": "Write",
-					"arguments": map[string]interface{}{
-						"file_path": "/test/output.txt",
-						"content":   "test content",
-					},
+		{
+			name:   "missing session ID",
+			method: http.MethodPost,
+			payload: HookData{
+				Event:     "PostToolUse",
+				Timestamp: time.Now().Format(time.RFC3339),
+				// SessionID missing
+				Filename: "activity-monitor",
+				Data: map[string]interface{}{
+					"response": "Test response content",
 				},
 			},
-			"execution_time": 2300,
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "session_id is required",
+			expectSuccess:  false,
+		},
+		{
+			name:   "missing response data",
+			method: http.MethodPost,
+			payload: HookData{
+				Event:     "PostToolUse",
+				Timestamp: time.Now().Format(time.RFC3339),
+				SessionID: "test-session-123",
+				Filename:  "activity-monitor",
+				Data: map[string]interface{}{
+					// response missing
+					"tool_calls": []interface{}{},
+				},
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "no response content in request",
+			expectSuccess:  false,
+		},
+		{
+			name:   "invalid response data type",
+			method: http.MethodPost,
+			payload: HookData{
+				Event:     "PostToolUse",
+				Timestamp: time.Now().Format(time.RFC3339),
+				SessionID: "test-session-123",
+				Filename:  "activity-monitor",
+				Data: map[string]interface{}{
+					"response": 456, // Should be string, not number
+				},
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "no response content in request",
+			expectSuccess:  false,
+		},
+		{
+			name:   "response with complex tool calls",
+			method: http.MethodPost,
+			payload: HookData{
+				Event:     "PostToolUse",
+				Timestamp: time.Now().Format(time.RFC3339),
+				SessionID: "test-session-789",
+				Filename:  "activity-monitor",
+				Data: map[string]interface{}{
+					"response": "Used Read tool to check file contents",
+					"tool_calls": []map[string]interface{}{
+						{
+							"name": "Read",
+							"arguments": map[string]interface{}{
+								"file_path": "/test/example.txt",
+								"limit":     100,
+							},
+						},
+						{
+							"name": "Write",
+							"arguments": map[string]interface{}{
+								"file_path": "/test/output.txt",
+								"content":   "test content",
+							},
+						},
+					},
+					"execution_time": 2300,
+				},
+			},
+			expectedStatus: http.StatusCreated,
+			expectSuccess:  true,
+			validateData: func(t *testing.T, data map[string]interface{}) {
+				if data["type"] != "response" {
+					t.Errorf("Expected type 'response', got %v", data["type"])
+				}
+				if data["session_id"] != "test-session-789" {
+					t.Errorf("Expected session_id 'test-session-789', got %v", data["session_id"])
+				}
+			},
 		},
 	}
-	
-	payload, _ := json.Marshal(hookData)
-	
-	req := httptest.NewRequest(http.MethodPost, "/messages/response", bytes.NewBuffer(payload))
-	req.Header.Set("Content-Type", "application/json")
-	
-	w := httptest.NewRecorder()
-	handler.HandleResponseSubmit(w, req)
-	
-	if w.Code != http.StatusCreated {
-		t.Errorf("Expected status %d, got %d", http.StatusCreated, w.Code)
-	}
-	
-	var response APIResponse
-	json.NewDecoder(w.Body).Decode(&response)
-	
-	if !response.Success {
-		t.Error("Expected response.Success to be true")
-	}
-	
-	// Verify that tool calls data is preserved
-	data := response.Data.(map[string]interface{})
-	if data["type"] != "response" {
-		t.Errorf("Expected type 'response', got %v", data["type"])
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := setupTestDB(t)
+			defer db.Close()
+			
+			handler := NewResponseHandler(db)
+			
+			// Prepare request
+			var req *http.Request
+			if tt.payload == nil {
+				req = httptest.NewRequest(tt.method, "/messages/response", nil)
+			} else if str, ok := tt.payload.(string); ok {
+				// Handle string payload (invalid JSON case)
+				req = httptest.NewRequest(tt.method, "/messages/response", bytes.NewBufferString(str))
+			} else {
+				// Handle struct payload
+				payload, err := json.Marshal(tt.payload)
+				if err != nil {
+					t.Fatalf("Failed to marshal test payload: %v", err)
+				}
+				req = httptest.NewRequest(tt.method, "/messages/response", bytes.NewBuffer(payload))
+			}
+			
+			if tt.method == http.MethodPost {
+				req.Header.Set("Content-Type", "application/json")
+			}
+			
+			// Execute request
+			w := httptest.NewRecorder()
+			handler.HandleResponseSubmit(w, req)
+			
+			// Check status code
+			if w.Code != tt.expectedStatus {
+				t.Errorf("Expected status %d, got %d", tt.expectedStatus, w.Code)
+			}
+			
+			// Parse response
+			var response APIResponse
+			if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+				t.Fatalf("Failed to decode response: %v", err)
+			}
+			
+			// Check success flag
+			if response.Success != tt.expectSuccess {
+				t.Errorf("Expected success %v, got %v", tt.expectSuccess, response.Success)
+			}
+			
+			// Check error message
+			if tt.expectedError != "" {
+				if response.Error == nil {
+					t.Errorf("Expected error '%s', got nil", tt.expectedError)
+				} else if *response.Error != tt.expectedError {
+					t.Errorf("Expected error '%s', got '%s'", tt.expectedError, *response.Error)
+				}
+			} else if response.Error != nil {
+				t.Errorf("Expected no error, got '%s'", *response.Error)
+			}
+			
+			// Custom data validation
+			if tt.validateData != nil && response.Success {
+				data, ok := response.Data.(map[string]interface{})
+				if !ok {
+					t.Fatal("Expected response.Data to be a map")
+				}
+				tt.validateData(t, data)
+			}
+		})
 	}
 }
 
@@ -335,8 +260,8 @@ func TestResponseHandler_ConversationCreation(t *testing.T) {
 		SessionID: "new-session-999",
 		Filename:  "activity-monitor",
 		Data: map[string]interface{}{
-			"response":       "Assistant response without prior prompt",
-			"cwd":            "/new/directory",
+			"response":        "Assistant response without prior prompt",
+			"cwd":             "/new/directory",
 			"transcript_path": "/new/transcript.md",
 		},
 	}

--- a/apps/prompt_manager/internal/api/handlers/response_handler_test.go
+++ b/apps/prompt_manager/internal/api/handlers/response_handler_test.go
@@ -1,0 +1,372 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestNewResponseHandler(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	
+	handler := NewResponseHandler(db)
+	
+	if handler == nil {
+		t.Fatal("Expected handler to be created, got nil")
+	}
+	
+	if handler.db != db {
+		t.Error("Expected handler to store database reference")
+	}
+}
+
+func TestResponseHandler_HandleResponseSubmit_Success(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	
+	handler := NewResponseHandler(db)
+	
+	// Create test payload
+	hookData := HookData{
+		Event:     "PostToolUse",
+		Timestamp: time.Now().Format(time.RFC3339),
+		SessionID: "test-session-456",
+		Filename:  "activity-monitor",
+		Data: map[string]interface{}{
+			"response": "This is an assistant response",
+			"tool_calls": []map[string]interface{}{
+				{
+					"name":      "Read",
+					"arguments": map[string]interface{}{"file_path": "/test/file.txt"},
+				},
+			},
+			"execution_time": 1500, // milliseconds
+		},
+	}
+	
+	payload, err := json.Marshal(hookData)
+	if err != nil {
+		t.Fatalf("Failed to marshal test data: %v", err)
+	}
+	
+	// Create request
+	req := httptest.NewRequest(http.MethodPost, "/messages/response", bytes.NewBuffer(payload))
+	req.Header.Set("Content-Type", "application/json")
+	
+	// Create response recorder
+	w := httptest.NewRecorder()
+	
+	// Execute request
+	handler.HandleResponseSubmit(w, req)
+	
+	// Check response
+	if w.Code != http.StatusCreated {
+		t.Errorf("Expected status %d, got %d", http.StatusCreated, w.Code)
+	}
+	
+	// Parse response
+	var response APIResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	
+	if !response.Success {
+		t.Error("Expected response.Success to be true")
+	}
+	
+	if response.Error != nil {
+		t.Errorf("Expected no error, got %s", *response.Error)
+	}
+	
+	// Verify data structure
+	data, ok := response.Data.(map[string]interface{})
+	if !ok {
+		t.Fatal("Expected response.Data to be a map")
+	}
+	
+	if data["session_id"] != hookData.SessionID {
+		t.Errorf("Expected session_id %s, got %v", hookData.SessionID, data["session_id"])
+	}
+	
+	if data["type"] != "response" {
+		t.Errorf("Expected type 'response', got %v", data["type"])
+	}
+}
+
+func TestResponseHandler_HandleResponseSubmit_MethodNotAllowed(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	
+	handler := NewResponseHandler(db)
+	
+	// Test GET request (not allowed)
+	req := httptest.NewRequest(http.MethodGet, "/messages/response", nil)
+	w := httptest.NewRecorder()
+	
+	handler.HandleResponseSubmit(w, req)
+	
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("Expected status %d, got %d", http.StatusMethodNotAllowed, w.Code)
+	}
+	
+	var response APIResponse
+	json.NewDecoder(w.Body).Decode(&response)
+	
+	if response.Success {
+		t.Error("Expected response.Success to be false")
+	}
+	
+	if response.Error == nil || *response.Error != "Method not allowed" {
+		t.Error("Expected 'Method not allowed' error")
+	}
+}
+
+func TestResponseHandler_HandleResponseSubmit_InvalidJSON(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	
+	handler := NewResponseHandler(db)
+	
+	// Create request with invalid JSON
+	req := httptest.NewRequest(http.MethodPost, "/messages/response", bytes.NewBufferString("invalid json"))
+	req.Header.Set("Content-Type", "application/json")
+	
+	w := httptest.NewRecorder()
+	handler.HandleResponseSubmit(w, req)
+	
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+	
+	var response APIResponse
+	json.NewDecoder(w.Body).Decode(&response)
+	
+	if response.Success {
+		t.Error("Expected response.Success to be false")
+	}
+}
+
+func TestResponseHandler_HandleResponseSubmit_MissingSessionID(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	
+	handler := NewResponseHandler(db)
+	
+	// Create payload without session_id
+	hookData := HookData{
+		Event:     "PostToolUse",
+		Timestamp: time.Now().Format(time.RFC3339),
+		// SessionID missing
+		Filename: "activity-monitor",
+		Data: map[string]interface{}{
+			"response": "Test response content",
+		},
+	}
+	
+	payload, _ := json.Marshal(hookData)
+	
+	req := httptest.NewRequest(http.MethodPost, "/messages/response", bytes.NewBuffer(payload))
+	req.Header.Set("Content-Type", "application/json")
+	
+	w := httptest.NewRecorder()
+	handler.HandleResponseSubmit(w, req)
+	
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+	
+	var response APIResponse
+	json.NewDecoder(w.Body).Decode(&response)
+	
+	if response.Success {
+		t.Error("Expected response.Success to be false")
+	}
+}
+
+func TestResponseHandler_HandleResponseSubmit_MissingResponseData(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	
+	handler := NewResponseHandler(db)
+	
+	// Create payload without response data
+	hookData := HookData{
+		Event:     "PostToolUse",
+		Timestamp: time.Now().Format(time.RFC3339),
+		SessionID: "test-session-123",
+		Filename:  "activity-monitor",
+		Data: map[string]interface{}{
+			// response missing
+			"tool_calls": []interface{}{},
+		},
+	}
+	
+	payload, _ := json.Marshal(hookData)
+	
+	req := httptest.NewRequest(http.MethodPost, "/messages/response", bytes.NewBuffer(payload))
+	req.Header.Set("Content-Type", "application/json")
+	
+	w := httptest.NewRecorder()
+	handler.HandleResponseSubmit(w, req)
+	
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+	
+	var response APIResponse
+	json.NewDecoder(w.Body).Decode(&response)
+	
+	if response.Success {
+		t.Error("Expected response.Success to be false")
+	}
+}
+
+func TestResponseHandler_HandleResponseSubmit_InvalidResponseDataType(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	
+	handler := NewResponseHandler(db)
+	
+	// Create payload with non-string response data
+	hookData := HookData{
+		Event:     "PostToolUse",
+		Timestamp: time.Now().Format(time.RFC3339),
+		SessionID: "test-session-123",
+		Filename:  "activity-monitor",
+		Data: map[string]interface{}{
+			"response": 456, // Should be string, not number
+		},
+	}
+	
+	payload, _ := json.Marshal(hookData)
+	
+	req := httptest.NewRequest(http.MethodPost, "/messages/response", bytes.NewBuffer(payload))
+	req.Header.Set("Content-Type", "application/json")
+	
+	w := httptest.NewRecorder()
+	handler.HandleResponseSubmit(w, req)
+	
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+	
+	var response APIResponse
+	json.NewDecoder(w.Body).Decode(&response)
+	
+	if response.Success {
+		t.Error("Expected response.Success to be false")
+	}
+}
+
+func TestResponseHandler_HandleResponseSubmit_WithToolCalls(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	
+	handler := NewResponseHandler(db)
+	
+	// Create test payload with tool calls
+	hookData := HookData{
+		Event:     "PostToolUse",
+		Timestamp: time.Now().Format(time.RFC3339),
+		SessionID: "test-session-789",
+		Filename:  "activity-monitor",
+		Data: map[string]interface{}{
+			"response": "Used Read tool to check file contents",
+			"tool_calls": []map[string]interface{}{
+				{
+					"name": "Read",
+					"arguments": map[string]interface{}{
+						"file_path": "/test/example.txt",
+						"limit":     100,
+					},
+				},
+				{
+					"name": "Write",
+					"arguments": map[string]interface{}{
+						"file_path": "/test/output.txt",
+						"content":   "test content",
+					},
+				},
+			},
+			"execution_time": 2300,
+		},
+	}
+	
+	payload, _ := json.Marshal(hookData)
+	
+	req := httptest.NewRequest(http.MethodPost, "/messages/response", bytes.NewBuffer(payload))
+	req.Header.Set("Content-Type", "application/json")
+	
+	w := httptest.NewRecorder()
+	handler.HandleResponseSubmit(w, req)
+	
+	if w.Code != http.StatusCreated {
+		t.Errorf("Expected status %d, got %d", http.StatusCreated, w.Code)
+	}
+	
+	var response APIResponse
+	json.NewDecoder(w.Body).Decode(&response)
+	
+	if !response.Success {
+		t.Error("Expected response.Success to be true")
+	}
+	
+	// Verify that tool calls data is preserved
+	data := response.Data.(map[string]interface{})
+	if data["type"] != "response" {
+		t.Errorf("Expected type 'response', got %v", data["type"])
+	}
+}
+
+func TestResponseHandler_ConversationCreation(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	
+	handler := NewResponseHandler(db)
+	
+	// Submit response for new session (should create conversation)
+	hookData := HookData{
+		Event:     "PostToolUse",
+		Timestamp: time.Now().Format(time.RFC3339),
+		SessionID: "new-session-999",
+		Filename:  "activity-monitor",
+		Data: map[string]interface{}{
+			"response":       "Assistant response without prior prompt",
+			"cwd":            "/new/directory",
+			"transcript_path": "/new/transcript.md",
+		},
+	}
+	
+	payload, _ := json.Marshal(hookData)
+	
+	req := httptest.NewRequest(http.MethodPost, "/messages/response", bytes.NewBuffer(payload))
+	req.Header.Set("Content-Type", "application/json")
+	
+	w := httptest.NewRecorder()
+	handler.HandleResponseSubmit(w, req)
+	
+	if w.Code != http.StatusCreated {
+		t.Errorf("Expected status %d, got %d", http.StatusCreated, w.Code)
+	}
+	
+	var response APIResponse
+	json.NewDecoder(w.Body).Decode(&response)
+	
+	if !response.Success {
+		t.Error("Expected response.Success to be true")
+	}
+	
+	// Verify conversation was created
+	data := response.Data.(map[string]interface{})
+	if data["conversation_id"] == nil {
+		t.Error("Expected conversation_id to be set")
+	}
+	
+	if data["session_id"] != hookData.SessionID {
+		t.Errorf("Expected session_id %s, got %v", hookData.SessionID, data["session_id"])
+	}
+}

--- a/apps/prompt_manager/internal/api/handlers/response_handler_test.go
+++ b/apps/prompt_manager/internal/api/handlers/response_handler_test.go
@@ -179,6 +179,8 @@ func TestResponseHandler_HandleResponseSubmit(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			
 			db := setupTestDB(t)
 			defer db.Close()
 			

--- a/apps/prompt_manager/internal/api/handlers/session_handler_test.go
+++ b/apps/prompt_manager/internal/api/handlers/session_handler_test.go
@@ -162,6 +162,8 @@ func TestSessionHandler_HandleSessionEvent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			
 			db := setupTestDB(t)
 			defer db.Close()
 			

--- a/apps/prompt_manager/internal/api/handlers/session_handler_test.go
+++ b/apps/prompt_manager/internal/api/handlers/session_handler_test.go
@@ -1,0 +1,326 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestNewSessionHandler(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	
+	handler := NewSessionHandler(db)
+	
+	if handler == nil {
+		t.Fatal("Expected handler to be created, got nil")
+	}
+	
+	if handler.db != db {
+		t.Error("Expected handler to store database reference")
+	}
+}
+
+func TestSessionHandler_HandleSessionEvent_SessionStart(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	
+	handler := NewSessionHandler(db)
+	
+	// Create test payload for session start
+	hookData := HookData{
+		Event:     "SessionStart",
+		Timestamp: time.Now().Format(time.RFC3339),
+		SessionID: "test-session-start-123",
+		Filename:  "activity-monitor",
+		Data: map[string]interface{}{
+			"cwd":             "/test/start/directory",
+			"transcript_path": "/test/transcript-start.md",
+		},
+	}
+	
+	payload, err := json.Marshal(hookData)
+	if err != nil {
+		t.Fatalf("Failed to marshal test data: %v", err)
+	}
+	
+	// Create request
+	req := httptest.NewRequest(http.MethodPost, "/messages/session", bytes.NewBuffer(payload))
+	req.Header.Set("Content-Type", "application/json")
+	
+	// Create response recorder
+	w := httptest.NewRecorder()
+	
+	// Execute request
+	handler.HandleSessionEvent(w, req)
+	
+	// Check response
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status %d, got %d", http.StatusOK, w.Code)
+	}
+	
+	// Parse response
+	var response APIResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	
+	if !response.Success {
+		t.Error("Expected response.Success to be true")
+	}
+	
+	if response.Error != nil {
+		t.Errorf("Expected no error, got %s", *response.Error)
+	}
+	
+	// Verify data structure
+	data, ok := response.Data.(map[string]interface{})
+	if !ok {
+		t.Fatal("Expected response.Data to be a map")
+	}
+	
+	if data["session_id"] != hookData.SessionID {
+		t.Errorf("Expected session_id %s, got %v", hookData.SessionID, data["session_id"])
+	}
+	
+	if data["event"] != "session_start" {
+		t.Errorf("Expected event 'session_start', got %v", data["event"])
+	}
+}
+
+func TestSessionHandler_HandleSessionEvent_SessionEnd(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	
+	handler := NewSessionHandler(db)
+	
+	// Create test payload for session end
+	hookData := HookData{
+		Event:     "SessionEnd",
+		Timestamp: time.Now().Format(time.RFC3339),
+		SessionID: "test-session-end-456",
+		Filename:  "activity-monitor",
+		Data: map[string]interface{}{
+			"duration":        3600000, // 1 hour in milliseconds
+			"total_messages":  25,
+			"conversation_id": 123,
+		},
+	}
+	
+	payload, err := json.Marshal(hookData)
+	if err != nil {
+		t.Fatalf("Failed to marshal test data: %v", err)
+	}
+	
+	// Create request
+	req := httptest.NewRequest(http.MethodPost, "/messages/session", bytes.NewBuffer(payload))
+	req.Header.Set("Content-Type", "application/json")
+	
+	// Create response recorder
+	w := httptest.NewRecorder()
+	
+	// Execute request
+	handler.HandleSessionEvent(w, req)
+	
+	// Check response
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status %d, got %d", http.StatusOK, w.Code)
+	}
+	
+	// Parse response
+	var response APIResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	
+	if !response.Success {
+		t.Error("Expected response.Success to be true")
+	}
+	
+	if response.Error != nil {
+		t.Errorf("Expected no error, got %s", *response.Error)
+	}
+}
+
+func TestSessionHandler_HandleSessionEvent_MethodNotAllowed(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	
+	handler := NewSessionHandler(db)
+	
+	// Test GET request (not allowed)
+	req := httptest.NewRequest(http.MethodGet, "/messages/session", nil)
+	w := httptest.NewRecorder()
+	
+	handler.HandleSessionEvent(w, req)
+	
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("Expected status %d, got %d", http.StatusMethodNotAllowed, w.Code)
+	}
+	
+	var response APIResponse
+	json.NewDecoder(w.Body).Decode(&response)
+	
+	if response.Success {
+		t.Error("Expected response.Success to be false")
+	}
+	
+	if response.Error == nil || *response.Error != "Method not allowed" {
+		t.Error("Expected 'Method not allowed' error")
+	}
+}
+
+func TestSessionHandler_HandleSessionEvent_InvalidJSON(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	
+	handler := NewSessionHandler(db)
+	
+	// Create request with invalid JSON
+	req := httptest.NewRequest(http.MethodPost, "/messages/session", bytes.NewBufferString("invalid json"))
+	req.Header.Set("Content-Type", "application/json")
+	
+	w := httptest.NewRecorder()
+	handler.HandleSessionEvent(w, req)
+	
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+	
+	var response APIResponse
+	json.NewDecoder(w.Body).Decode(&response)
+	
+	if response.Success {
+		t.Error("Expected response.Success to be false")
+	}
+}
+
+func TestSessionHandler_HandleSessionEvent_MissingSessionID(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	
+	handler := NewSessionHandler(db)
+	
+	// Create payload without session_id
+	hookData := HookData{
+		Event:     "SessionStart",
+		Timestamp: time.Now().Format(time.RFC3339),
+		// SessionID missing
+		Filename: "activity-monitor",
+		Data: map[string]interface{}{
+			"cwd": "/test/directory",
+		},
+	}
+	
+	payload, _ := json.Marshal(hookData)
+	
+	req := httptest.NewRequest(http.MethodPost, "/messages/session", bytes.NewBuffer(payload))
+	req.Header.Set("Content-Type", "application/json")
+	
+	w := httptest.NewRecorder()
+	handler.HandleSessionEvent(w, req)
+	
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+	
+	var response APIResponse
+	json.NewDecoder(w.Body).Decode(&response)
+	
+	if response.Success {
+		t.Error("Expected response.Success to be false")
+	}
+}
+
+func TestSessionHandler_HandleSessionEvent_UnknownEvent(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	
+	handler := NewSessionHandler(db)
+	
+	// Create test payload for unknown event
+	hookData := HookData{
+		Event:     "CustomEvent",
+		Timestamp: time.Now().Format(time.RFC3339),
+		SessionID: "test-session-unknown-789",
+		Filename:  "activity-monitor",
+		Data: map[string]interface{}{
+			"custom_field": "custom_value",
+			"number_field": 42,
+		},
+	}
+	
+	payload, _ := json.Marshal(hookData)
+	
+	req := httptest.NewRequest(http.MethodPost, "/messages/session", bytes.NewBuffer(payload))
+	req.Header.Set("Content-Type", "application/json")
+	
+	w := httptest.NewRecorder()
+	handler.HandleSessionEvent(w, req)
+	
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+	
+	var response APIResponse
+	json.NewDecoder(w.Body).Decode(&response)
+	
+	if response.Success {
+		t.Error("Expected response.Success to be false")
+	}
+	
+	if response.Error == nil {
+		t.Error("Expected error message for unknown event")
+	}
+}
+
+func TestSessionHandler_ConversationCreation(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	
+	handler := NewSessionHandler(db)
+	
+	// Submit session event for new session (should create conversation)
+	hookData := HookData{
+		Event:     "SessionStart",
+		Timestamp: time.Now().Format(time.RFC3339),
+		SessionID: "new-session-conversation-test",
+		Filename:  "activity-monitor",
+		Data: map[string]interface{}{
+			"cwd":             "/session/test/directory",
+			"transcript_path": "/session/test/transcript.md",
+		},
+	}
+	
+	payload, _ := json.Marshal(hookData)
+	
+	req := httptest.NewRequest(http.MethodPost, "/messages/session", bytes.NewBuffer(payload))
+	req.Header.Set("Content-Type", "application/json")
+	
+	w := httptest.NewRecorder()
+	handler.HandleSessionEvent(w, req)
+	
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status %d, got %d", http.StatusOK, w.Code)
+	}
+	
+	var response APIResponse
+	json.NewDecoder(w.Body).Decode(&response)
+	
+	if !response.Success {
+		t.Error("Expected response.Success to be true")
+	}
+	
+	// Verify conversation was created
+	data := response.Data.(map[string]interface{})
+	if data["conversation_id"] == nil {
+		t.Error("Expected conversation_id to be set")
+	}
+	
+	if data["session_id"] != hookData.SessionID {
+		t.Errorf("Expected session_id %s, got %v", hookData.SessionID, data["session_id"])
+	}
+}

--- a/apps/prompt_manager/internal/api/handlers/session_handler_test.go
+++ b/apps/prompt_manager/internal/api/handlers/session_handler_test.go
@@ -24,256 +24,209 @@ func TestNewSessionHandler(t *testing.T) {
 	}
 }
 
-func TestSessionHandler_HandleSessionEvent_SessionStart(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	
-	handler := NewSessionHandler(db)
-	
-	// Create test payload for session start
-	hookData := HookData{
-		Event:     "SessionStart",
-		Timestamp: time.Now().Format(time.RFC3339),
-		SessionID: "test-session-start-123",
-		Filename:  "activity-monitor",
-		Data: map[string]interface{}{
-			"cwd":             "/test/start/directory",
-			"transcript_path": "/test/transcript-start.md",
+func TestSessionHandler_HandleSessionEvent(t *testing.T) {
+	tests := []struct {
+		name           string
+		method         string
+		payload        interface{}
+		expectedStatus int
+		expectedError  string
+		expectSuccess  bool
+		validateData   func(t *testing.T, data map[string]interface{})
+	}{
+		{
+			name:   "session start event",
+			method: http.MethodPost,
+			payload: HookData{
+				Event:     "SessionStart",
+				Timestamp: time.Now().Format(time.RFC3339),
+				SessionID: "test-session-start-123",
+				Filename:  "activity-monitor",
+				Data: map[string]interface{}{
+					"cwd":             "/test/start/directory",
+					"transcript_path": "/test/transcript-start.md",
+				},
+			},
+			expectedStatus: http.StatusOK,
+			expectSuccess:  true,
+			validateData: func(t *testing.T, data map[string]interface{}) {
+				if data["session_id"] != "test-session-start-123" {
+					t.Errorf("Expected session_id 'test-session-start-123', got %v", data["session_id"])
+				}
+				if data["event"] != "session_start" {
+					t.Errorf("Expected event 'session_start', got %v", data["event"])
+				}
+				if data["conversation_id"] == nil {
+					t.Error("Expected conversation_id to be set")
+				}
+			},
+		},
+		{
+			name:   "session end event",
+			method: http.MethodPost,
+			payload: HookData{
+				Event:     "SessionEnd",
+				Timestamp: time.Now().Format(time.RFC3339),
+				SessionID: "test-session-end-456",
+				Filename:  "activity-monitor",
+				Data: map[string]interface{}{
+					"duration":        3600000,
+					"total_messages":  25,
+					"conversation_id": 123,
+				},
+			},
+			expectedStatus: http.StatusOK,
+			expectSuccess:  true,
+			validateData: func(t *testing.T, data map[string]interface{}) {
+				if data["session_id"] != "test-session-end-456" {
+					t.Errorf("Expected session_id 'test-session-end-456', got %v", data["session_id"])
+				}
+				if data["event"] != "session_end" {
+					t.Errorf("Expected event 'session_end', got %v", data["event"])
+				}
+			},
+		},
+		{
+			name:   "stop event (alias for session end)",
+			method: http.MethodPost,
+			payload: HookData{
+				Event:     "Stop",
+				Timestamp: time.Now().Format(time.RFC3339),
+				SessionID: "test-session-stop-789",
+				Filename:  "activity-monitor",
+				Data: map[string]interface{}{
+					"duration": 1800000,
+				},
+			},
+			expectedStatus: http.StatusOK,
+			expectSuccess:  true,
+			validateData: func(t *testing.T, data map[string]interface{}) {
+				if data["session_id"] != "test-session-stop-789" {
+					t.Errorf("Expected session_id 'test-session-stop-789', got %v", data["session_id"])
+				}
+				if data["event"] != "session_end" {
+					t.Errorf("Expected event 'session_end', got %v", data["event"])
+				}
+			},
+		},
+		{
+			name:           "method not allowed",
+			method:         http.MethodGet,
+			payload:        nil,
+			expectedStatus: http.StatusMethodNotAllowed,
+			expectedError:  "Method not allowed",
+			expectSuccess:  false,
+		},
+		{
+			name:           "invalid JSON",
+			method:         http.MethodPost,
+			payload:        "invalid json",
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "Invalid JSON request body",
+			expectSuccess:  false,
+		},
+		{
+			name:   "missing session ID",
+			method: http.MethodPost,
+			payload: HookData{
+				Event:     "SessionStart",
+				Timestamp: time.Now().Format(time.RFC3339),
+				// SessionID missing
+				Filename: "activity-monitor",
+				Data: map[string]interface{}{
+					"cwd": "/test/directory",
+				},
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "session_id is required",
+			expectSuccess:  false,
+		},
+		{
+			name:   "unknown event type",
+			method: http.MethodPost,
+			payload: HookData{
+				Event:     "CustomEvent",
+				Timestamp: time.Now().Format(time.RFC3339),
+				SessionID: "test-session-unknown-789",
+				Filename:  "activity-monitor",
+				Data: map[string]interface{}{
+					"custom_field": "custom_value",
+					"number_field": 42,
+				},
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "Unknown session event: CustomEvent",
+			expectSuccess:  false,
 		},
 	}
-	
-	payload, err := json.Marshal(hookData)
-	if err != nil {
-		t.Fatalf("Failed to marshal test data: %v", err)
-	}
-	
-	// Create request
-	req := httptest.NewRequest(http.MethodPost, "/messages/session", bytes.NewBuffer(payload))
-	req.Header.Set("Content-Type", "application/json")
-	
-	// Create response recorder
-	w := httptest.NewRecorder()
-	
-	// Execute request
-	handler.HandleSessionEvent(w, req)
-	
-	// Check response
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected status %d, got %d", http.StatusOK, w.Code)
-	}
-	
-	// Parse response
-	var response APIResponse
-	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
-		t.Fatalf("Failed to decode response: %v", err)
-	}
-	
-	if !response.Success {
-		t.Error("Expected response.Success to be true")
-	}
-	
-	if response.Error != nil {
-		t.Errorf("Expected no error, got %s", *response.Error)
-	}
-	
-	// Verify data structure
-	data, ok := response.Data.(map[string]interface{})
-	if !ok {
-		t.Fatal("Expected response.Data to be a map")
-	}
-	
-	if data["session_id"] != hookData.SessionID {
-		t.Errorf("Expected session_id %s, got %v", hookData.SessionID, data["session_id"])
-	}
-	
-	if data["event"] != "session_start" {
-		t.Errorf("Expected event 'session_start', got %v", data["event"])
-	}
-}
 
-func TestSessionHandler_HandleSessionEvent_SessionEnd(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	
-	handler := NewSessionHandler(db)
-	
-	// Create test payload for session end
-	hookData := HookData{
-		Event:     "SessionEnd",
-		Timestamp: time.Now().Format(time.RFC3339),
-		SessionID: "test-session-end-456",
-		Filename:  "activity-monitor",
-		Data: map[string]interface{}{
-			"duration":        3600000, // 1 hour in milliseconds
-			"total_messages":  25,
-			"conversation_id": 123,
-		},
-	}
-	
-	payload, err := json.Marshal(hookData)
-	if err != nil {
-		t.Fatalf("Failed to marshal test data: %v", err)
-	}
-	
-	// Create request
-	req := httptest.NewRequest(http.MethodPost, "/messages/session", bytes.NewBuffer(payload))
-	req.Header.Set("Content-Type", "application/json")
-	
-	// Create response recorder
-	w := httptest.NewRecorder()
-	
-	// Execute request
-	handler.HandleSessionEvent(w, req)
-	
-	// Check response
-	if w.Code != http.StatusOK {
-		t.Errorf("Expected status %d, got %d", http.StatusOK, w.Code)
-	}
-	
-	// Parse response
-	var response APIResponse
-	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
-		t.Fatalf("Failed to decode response: %v", err)
-	}
-	
-	if !response.Success {
-		t.Error("Expected response.Success to be true")
-	}
-	
-	if response.Error != nil {
-		t.Errorf("Expected no error, got %s", *response.Error)
-	}
-}
-
-func TestSessionHandler_HandleSessionEvent_MethodNotAllowed(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	
-	handler := NewSessionHandler(db)
-	
-	// Test GET request (not allowed)
-	req := httptest.NewRequest(http.MethodGet, "/messages/session", nil)
-	w := httptest.NewRecorder()
-	
-	handler.HandleSessionEvent(w, req)
-	
-	if w.Code != http.StatusMethodNotAllowed {
-		t.Errorf("Expected status %d, got %d", http.StatusMethodNotAllowed, w.Code)
-	}
-	
-	var response APIResponse
-	json.NewDecoder(w.Body).Decode(&response)
-	
-	if response.Success {
-		t.Error("Expected response.Success to be false")
-	}
-	
-	if response.Error == nil || *response.Error != "Method not allowed" {
-		t.Error("Expected 'Method not allowed' error")
-	}
-}
-
-func TestSessionHandler_HandleSessionEvent_InvalidJSON(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	
-	handler := NewSessionHandler(db)
-	
-	// Create request with invalid JSON
-	req := httptest.NewRequest(http.MethodPost, "/messages/session", bytes.NewBufferString("invalid json"))
-	req.Header.Set("Content-Type", "application/json")
-	
-	w := httptest.NewRecorder()
-	handler.HandleSessionEvent(w, req)
-	
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("Expected status %d, got %d", http.StatusBadRequest, w.Code)
-	}
-	
-	var response APIResponse
-	json.NewDecoder(w.Body).Decode(&response)
-	
-	if response.Success {
-		t.Error("Expected response.Success to be false")
-	}
-}
-
-func TestSessionHandler_HandleSessionEvent_MissingSessionID(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	
-	handler := NewSessionHandler(db)
-	
-	// Create payload without session_id
-	hookData := HookData{
-		Event:     "SessionStart",
-		Timestamp: time.Now().Format(time.RFC3339),
-		// SessionID missing
-		Filename: "activity-monitor",
-		Data: map[string]interface{}{
-			"cwd": "/test/directory",
-		},
-	}
-	
-	payload, _ := json.Marshal(hookData)
-	
-	req := httptest.NewRequest(http.MethodPost, "/messages/session", bytes.NewBuffer(payload))
-	req.Header.Set("Content-Type", "application/json")
-	
-	w := httptest.NewRecorder()
-	handler.HandleSessionEvent(w, req)
-	
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("Expected status %d, got %d", http.StatusBadRequest, w.Code)
-	}
-	
-	var response APIResponse
-	json.NewDecoder(w.Body).Decode(&response)
-	
-	if response.Success {
-		t.Error("Expected response.Success to be false")
-	}
-}
-
-func TestSessionHandler_HandleSessionEvent_UnknownEvent(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	
-	handler := NewSessionHandler(db)
-	
-	// Create test payload for unknown event
-	hookData := HookData{
-		Event:     "CustomEvent",
-		Timestamp: time.Now().Format(time.RFC3339),
-		SessionID: "test-session-unknown-789",
-		Filename:  "activity-monitor",
-		Data: map[string]interface{}{
-			"custom_field": "custom_value",
-			"number_field": 42,
-		},
-	}
-	
-	payload, _ := json.Marshal(hookData)
-	
-	req := httptest.NewRequest(http.MethodPost, "/messages/session", bytes.NewBuffer(payload))
-	req.Header.Set("Content-Type", "application/json")
-	
-	w := httptest.NewRecorder()
-	handler.HandleSessionEvent(w, req)
-	
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("Expected status %d, got %d", http.StatusBadRequest, w.Code)
-	}
-	
-	var response APIResponse
-	json.NewDecoder(w.Body).Decode(&response)
-	
-	if response.Success {
-		t.Error("Expected response.Success to be false")
-	}
-	
-	if response.Error == nil {
-		t.Error("Expected error message for unknown event")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := setupTestDB(t)
+			defer db.Close()
+			
+			handler := NewSessionHandler(db)
+			
+			// Prepare request
+			var req *http.Request
+			if tt.payload == nil {
+				req = httptest.NewRequest(tt.method, "/messages/session", nil)
+			} else if str, ok := tt.payload.(string); ok {
+				// Handle string payload (invalid JSON case)
+				req = httptest.NewRequest(tt.method, "/messages/session", bytes.NewBufferString(str))
+			} else {
+				// Handle struct payload
+				payload, err := json.Marshal(tt.payload)
+				if err != nil {
+					t.Fatalf("Failed to marshal test payload: %v", err)
+				}
+				req = httptest.NewRequest(tt.method, "/messages/session", bytes.NewBuffer(payload))
+			}
+			
+			if tt.method == http.MethodPost {
+				req.Header.Set("Content-Type", "application/json")
+			}
+			
+			// Execute request
+			w := httptest.NewRecorder()
+			handler.HandleSessionEvent(w, req)
+			
+			// Check status code
+			if w.Code != tt.expectedStatus {
+				t.Errorf("Expected status %d, got %d", tt.expectedStatus, w.Code)
+			}
+			
+			// Parse response
+			var response APIResponse
+			if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+				t.Fatalf("Failed to decode response: %v", err)
+			}
+			
+			// Check success flag
+			if response.Success != tt.expectSuccess {
+				t.Errorf("Expected success %v, got %v", tt.expectSuccess, response.Success)
+			}
+			
+			// Check error message
+			if tt.expectedError != "" {
+				if response.Error == nil {
+					t.Errorf("Expected error '%s', got nil", tt.expectedError)
+				} else if *response.Error != tt.expectedError {
+					t.Errorf("Expected error '%s', got '%s'", tt.expectedError, *response.Error)
+				}
+			} else if response.Error != nil {
+				t.Errorf("Expected no error, got '%s'", *response.Error)
+			}
+			
+			// Custom data validation
+			if tt.validateData != nil && response.Success {
+				data, ok := response.Data.(map[string]interface{})
+				if !ok {
+					t.Fatal("Expected response.Data to be a map")
+				}
+				tt.validateData(t, data)
+			}
+		})
 	}
 }
 

--- a/apps/prompt_manager/internal/api/handlers/testutils_test.go
+++ b/apps/prompt_manager/internal/api/handlers/testutils_test.go
@@ -1,0 +1,32 @@
+package handlers
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/claude-code-template/prompt-manager/internal/database"
+)
+
+// setupTestDB creates a temporary test database with migrations applied
+func setupTestDB(t *testing.T) *database.DB {
+	// Create temporary database file
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+	
+	config := &database.Config{
+		DatabasePath:  dbPath,
+		MigrationsDir: "../../../database/migrations",
+	}
+	
+	db, err := database.New(config)
+	if err != nil {
+		t.Fatalf("Failed to create test database: %v", err)
+	}
+	
+	// Run migrations
+	if err := db.RunMigrations(config.MigrationsDir); err != nil {
+		t.Fatalf("Failed to run migrations: %v", err)
+	}
+	
+	return db
+}

--- a/apps/prompt_manager/internal/api/handlers/types.go
+++ b/apps/prompt_manager/internal/api/handlers/types.go
@@ -1,0 +1,17 @@
+package handlers
+
+// HookData represents the structure of hook data from Claude Code
+type HookData struct {
+	Event     string                 `json:"event"`
+	Timestamp string                 `json:"timestamp"`
+	SessionID string                 `json:"session_id"`
+	Filename  string                 `json:"filename"`
+	Data      map[string]interface{} `json:"data"`
+}
+
+// APIResponse represents a standard API response
+type APIResponse struct {
+	Success bool        `json:"success"`
+	Data    interface{} `json:"data,omitempty"`
+	Error   *string     `json:"error,omitempty"`
+}


### PR DESCRIPTION
Added unit testing

  ✅ Prompt Handler (8 tests)

  - Constructor validation
  - Successful prompt submission
  - HTTP method validation
  - JSON parsing errors
  - Missing session ID validation
  - Missing/invalid prompt data validation
  - Conversation creation and reuse

  ✅ Response Handler (8 tests)

  - Constructor validation
  - Successful response submission with tool calls
  - HTTP method validation
  - JSON parsing errors
  - Missing session ID validation
  - Missing/invalid response data validation
  - Tool calls data preservation
  - Conversation creation

  ✅ Session Handler (7 tests)

  - Constructor validation
  - Session start event handling
  - Session end event handling
  - HTTP method validation
  - JSON parsing errors
  - Missing session ID validation
  - Unknown event error handling
  - Conversation creation