### PR TITLE
fix: use relative source paths in marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,15 +5,13 @@
   },
   "metadata": {
     "description": "Security hooks, branch protection, and development skills for Claude Code projects",
-    "version": "1.0.0"
+    "version": "1.0.0",
+    "pluginRoot": "./plugins"
   },
   "plugins": [
     {
       "name": "security-hooks",
-      "source": {
-        "source": "github",
-        "repo": "rikdc/claude_code_template"
-      },
+      "source": "./plugins/security-hooks",
       "description": "MCP security scanner and protected branch hooks for Claude Code",
       "version": "1.0.0",
       "keywords": ["security", "hooks", "mcp", "branch-protection"],
@@ -21,10 +19,7 @@
     },
     {
       "name": "pr-review-triage",
-      "source": {
-        "source": "github",
-        "repo": "rikdc/claude_code_template"
-      },
+      "source": "./plugins/pr-review-triage",
       "description": "Triage PR review comments — classify, accept/reject, and track follow-up work",
       "version": "1.0.0",
       "keywords": ["pr-review", "triage", "code-review", "github", "workflow"],


### PR DESCRIPTION
## Summary

- Adds `"pluginRoot": "./plugins"` to marketplace metadata
- Changes plugin `source` fields from github objects to relative paths (e.g. `"./plugins/pr-review-triage"`)
- Matches the convention used by working marketplaces like `claudekit-skills`

## Context

The previous fix (#38) correctly moved `plugin.json` into `.claude-plugin/`, but the install still failed because the marketplace `source` fields used github objects instead of relative paths. This caused the installer to clone the entire repo as the plugin root rather than resolving the specific plugin subdirectory within the repo. As a result, there was no `.claude-plugin/plugin.json` or `skills/` directory at the install root, and Claude Code couldn't discover the skill.

## Test plan

- [ ] Uninstall `pr-review-triage`, reinstall from marketplace
- [ ] Restart Claude Code
- [ ] Verify `/triage` and `/triage-reviews` appear