### PR TITLE
fix: remove category from plugin.json manifests

### DIFF
--- a/plugins/code-quality/.claude-plugin/plugin.json
+++ b/plugins/code-quality/.claude-plugin/plugin.json
@@ -6,7 +6,6 @@
     "name": "Richard Claydon"
   },
   "license": "MIT",
-  "category": "development",
   "keywords": ["code-quality", "review", "linting", "cleanup"],
   "commands": ["./commands/"]
 }

--- a/plugins/dev-skills/.claude-plugin/plugin.json
+++ b/plugins/dev-skills/.claude-plugin/plugin.json
@@ -6,7 +6,6 @@
     "name": "Richard Claydon"
   },
   "license": "MIT",
-  "category": "development",
   "keywords": ["skills", "go", "documentation", "architecture", "mentorship"],
   "skills": ["./skills/"]
 }

--- a/plugins/git-workflow/.claude-plugin/plugin.json
+++ b/plugins/git-workflow/.claude-plugin/plugin.json
@@ -6,7 +6,6 @@
     "name": "Richard Claydon"
   },
   "license": "MIT",
-  "category": "productivity",
   "keywords": ["git", "github", "workflow", "changelog"],
   "commands": ["./commands/"]
 }

--- a/plugins/pm-tools/.claude-plugin/plugin.json
+++ b/plugins/pm-tools/.claude-plugin/plugin.json
@@ -6,7 +6,6 @@
     "name": "Richard Claydon"
   },
   "license": "MIT",
-  "category": "productivity",
   "keywords": ["project-management", "prd", "tasks", "planning"],
   "commands": ["./commands/"]
 }

--- a/plugins/pr-review-triage/.claude-plugin/plugin.json
+++ b/plugins/pr-review-triage/.claude-plugin/plugin.json
@@ -6,7 +6,6 @@
     "name": "Richard Claydon"
   },
   "license": "MIT",
-  "category": "workflow",
   "keywords": ["pr-review", "triage", "code-review", "github", "workflow"],
   "commands": ["./commands/"],
   "skills": ["./skills/"]

--- a/plugins/prompt-tools/.claude-plugin/plugin.json
+++ b/plugins/prompt-tools/.claude-plugin/plugin.json
@@ -6,7 +6,6 @@
     "name": "Richard Claydon"
   },
   "license": "MIT",
-  "category": "ai",
   "keywords": ["prompts", "ai", "llm", "prompt-engineering"],
   "commands": ["./commands/"]
 }

--- a/plugins/security-hooks/.claude-plugin/plugin.json
+++ b/plugins/security-hooks/.claude-plugin/plugin.json
@@ -6,7 +6,6 @@
     "name": "Richard Claydon"
   },
   "license": "MIT",
-  "category": "security",
   "keywords": ["security", "hooks", "mcp", "branch-protection"],
   "hooks": "./hooks.json"
 }


### PR DESCRIPTION
## Summary

- Removes `category` field from all 7 `.claude-plugin/plugin.json` files
- `category` is valid on marketplace entries but **not** in the plugin manifest schema ([docs](https://code.claude.com/docs/en/plugins-reference#plugin-manifest-schema))
- This was causing: `Plugin has an invalid manifest file... Validation errors: : Unrecognized key: "category"`

## Validated

- `claude plugin validate .` (marketplace): PASS
- `claude plugin validate` (all 7 plugins): PASS
- `claude --plugin-dir .../pr-review-triage`: `triage` + `triage-reviews` both discovered