### PR TITLE
fix(security-hooks): judge Bash on parsed argv, not tool name alone

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "security-hooks",
       "source": "./plugins/security-hooks",
       "description": "MCP security scanner and protected branch hooks for Claude Code",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "keywords": ["security", "hooks", "mcp", "branch-protection"],
       "category": "security"
     },

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+---
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+
+      - name: Verify required tools
+        run: |
+          jq --version
+          bash --version | head -1
+
+      - name: Run test suite
+        run: make test

--- a/plugins/security-hooks/.claude-plugin/plugin.json
+++ b/plugins/security-hooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "security-hooks",
   "description": "MCP security scanner and protected branch hooks for Claude Code",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Richard Claydon"
   },

--- a/plugins/security-hooks/hooks/protect-main-branch.sh
+++ b/plugins/security-hooks/hooks/protect-main-branch.sh
@@ -224,6 +224,9 @@ strip_wrappers() {
                     TOKENS=("${TOKENS[@]:1}")
                 done
                 ;;
+            *)
+                # Not a wrapper: TOKENS[0] is the real command.
+                ;;
         esac
     done
 }
@@ -237,6 +240,9 @@ git_subcommand_always_writes() {
     case "$1" in
         commit|push|merge|rebase|cherry-pick|revert|am|filter-branch|update-ref|fast-import)
             return 0
+            ;;
+        *)
+            # Read-only or index-only subcommand: status, diff, log, add, ...
             ;;
     esac
     return 1
@@ -257,6 +263,9 @@ git_reset_writes() {
                 # Path-limited unstage: git reset -- file
                 return 1
                 ;;
+            *)
+                # Keep scanning the remaining arguments.
+                ;;
         esac
     done
     # A bare commit-ish argument (git reset HEAD~1) moves the branch pointer.
@@ -275,6 +284,9 @@ git_branch_writes() {
         case "$arg" in
             -D|-d|--delete|-f|--force|-M|-m|--move|-C|--copy|--edit-description)
                 return 0
+                ;;
+            *)
+                # Listing or plain creation: harmless.
                 ;;
         esac
     done
@@ -301,6 +313,9 @@ git_checkout_writes() {
             --)
                 # Path restore: git checkout -- file. Does not move HEAD.
                 return 1
+                ;;
+            *)
+                # Keep scanning the remaining arguments.
                 ;;
         esac
     done
@@ -368,6 +383,9 @@ inspect_git() {
                 echo "git $subcommand moves HEAD off the protected branch"
                 return 0
             fi
+            ;;
+        *)
+            # Unrecognised subcommand: fail open, consistent with the parser.
             ;;
     esac
 

--- a/plugins/security-hooks/hooks/protect-main-branch.sh
+++ b/plugins/security-hooks/hooks/protect-main-branch.sh
@@ -69,11 +69,6 @@ This hook ensures repository safety and collaboration best practices."
 
 # ---------------------------------------------------------------------------
 # Shell parsing helpers
-#
-# The whole point of this hook's rewrite: decisions are made on parsed argv,
-# never on substring matches against the raw command string. A command like
-# "curl https://host/main | grep push" contains every dangerous-looking token
-# you can think of and must still be allowed through.
 # ---------------------------------------------------------------------------
 
 # Split a command string into pipeline/list segments on unquoted | ; & and
@@ -264,7 +259,6 @@ git_reset_writes() {
                 return 1
                 ;;
             *)
-                # Keep scanning the remaining arguments.
                 ;;
         esac
     done
@@ -315,7 +309,6 @@ git_checkout_writes() {
                 return 1
                 ;;
             *)
-                # Keep scanning the remaining arguments.
                 ;;
         esac
     done
@@ -402,7 +395,6 @@ inspect_git_dir_write() {
     local cmd
     cmd="$(basename -- "${args[0]:-}")"
 
-    # Redirection into .git/ regardless of the command driving it.
     if [[ "$raw" =~ \>\>?[[:space:]]*[^[:space:]]*\.git/ ]]; then
         echo "shell redirection writes under .git/"
         return 0
@@ -471,7 +463,6 @@ inspect_segment() {
     return 1
 }
 
-# Analyse a full command string across all its segments.
 inspect_command() {
     local command="$1"
     local depth="${2:-0}"
@@ -553,8 +544,7 @@ if [[ "$TOOL_NAME" == "Bash" ]]; then
 
     log_debug "Inspecting command: $COMMAND"
 
-    # Fail OPEN on anything unparseable. A blanket deny on commands the parser
-    # cannot understand is the exact failure mode this rewrite exists to fix.
+    # Fail open: anything the parser cannot read is allowed, not denied.
     if ! REASON="$(inspect_command "$COMMAND" 2>/dev/null)"; then
         log_info "Command is read-only or non-git, allowing: $COMMAND"
         allow

--- a/plugins/security-hooks/hooks/protect-main-branch.sh
+++ b/plugins/security-hooks/hooks/protect-main-branch.sh
@@ -35,6 +35,449 @@ deny() {
     exit 0
 }
 
+deny_branch_write() {
+    local detail="$1"
+    log_error "PROTECTED BRANCH VIOLATION: $detail on protected branch '$CURRENT_BRANCH'"
+    deny "Blocked on protected branch '$CURRENT_BRANCH': $detail
+
+Protected branches enforce PR-based workflows to ensure:
+- Code review and quality standards
+- CI/CD pipeline validation
+- Collaboration and knowledge sharing
+- Audit trail for all changes
+
+To proceed:
+1. Create a feature branch (this is allowed from a protected branch):
+   git checkout -b your-name/feature-description
+
+2. Make your changes on the feature branch
+
+3. Push and create a Pull Request:
+   git push -u origin your-name/feature-description
+
+Protected branches: ${PROTECTED_BRANCHES[*]}
+
+Read-only commands are not affected: git status, git diff, git log, git show,
+and every non-git command run through without inspection.
+
+For emergency changes, set ALLOW_PROTECTED_BRANCH_EDIT=1 in the environment
+Claude Code itself is launched with (the hook reads its own environment, so an
+inline VAR=1 prefix on the command will not reach it).
+
+This hook ensures repository safety and collaboration best practices."
+}
+
+# ---------------------------------------------------------------------------
+# Shell parsing helpers
+#
+# The whole point of this hook's rewrite: decisions are made on parsed argv,
+# never on substring matches against the raw command string. A command like
+# "curl https://host/main | grep push" contains every dangerous-looking token
+# you can think of and must still be allowed through.
+# ---------------------------------------------------------------------------
+
+# Split a command string into pipeline/list segments on unquoted | ; & and
+# newlines. Quotes and backslash escapes are respected so that separators
+# inside 'single quotes' or "double quotes" do not split the segment.
+SEGMENTS=()
+split_segments() {
+    local input="$1"
+    SEGMENTS=()
+
+    local current="" quote="" i char
+    for ((i = 0; i < ${#input}; i++)); do
+        char="${input:i:1}"
+
+        if [[ -n "$quote" ]]; then
+            current+="$char"
+            # Backslash escapes are only special inside double quotes.
+            if [[ "$char" == "\\" && "$quote" == '"' && $((i + 1)) -lt ${#input} ]]; then
+                ((i++))
+                current+="${input:i:1}"
+            elif [[ "$char" == "$quote" ]]; then
+                quote=""
+            fi
+            continue
+        fi
+
+        case "$char" in
+            "'"|'"')
+                quote="$char"
+                current+="$char"
+                ;;
+            "\\")
+                current+="$char"
+                if [[ $((i + 1)) -lt ${#input} ]]; then
+                    ((i++))
+                    current+="${input:i:1}"
+                fi
+                ;;
+            "|"|";"|"&"|$'\n')
+                SEGMENTS+=("$current")
+                current=""
+                ;;
+            *)
+                current+="$char"
+                ;;
+        esac
+    done
+
+    SEGMENTS+=("$current")
+}
+
+# Tokenize one segment into argv, stripping one level of quoting.
+TOKENS=()
+tokenize() {
+    local input="$1"
+    TOKENS=()
+
+    local current="" quote="" started=0 i char
+    for ((i = 0; i < ${#input}; i++)); do
+        char="${input:i:1}"
+
+        if [[ -n "$quote" ]]; then
+            if [[ "$char" == "\\" && "$quote" == '"' && $((i + 1)) -lt ${#input} ]]; then
+                ((i++))
+                current+="${input:i:1}"
+            elif [[ "$char" == "$quote" ]]; then
+                quote=""
+            else
+                current+="$char"
+            fi
+            continue
+        fi
+
+        case "$char" in
+            "'"|'"')
+                quote="$char"
+                started=1
+                ;;
+            "\\")
+                if [[ $((i + 1)) -lt ${#input} ]]; then
+                    ((i++))
+                    current+="${input:i:1}"
+                    started=1
+                fi
+                ;;
+            " "|$'\t'|$'\r')
+                if [[ $started -eq 1 ]]; then
+                    TOKENS+=("$current")
+                    current=""
+                    started=0
+                fi
+                ;;
+            *)
+                current+="$char"
+                started=1
+                ;;
+        esac
+    done
+
+    if [[ $started -eq 1 ]]; then
+        TOKENS+=("$current")
+    fi
+}
+
+# Drop leading VAR=value assignments and transparent wrappers (sudo, env, nice,
+# time, ...) so that TOKENS[0] is the command that actually runs. Wrapper flags
+# that take a value are consumed alongside the wrapper.
+strip_wrappers() {
+    local changed=1
+    while [[ $changed -eq 1 && ${#TOKENS[@]} -gt 0 ]]; do
+        changed=0
+
+        # Leading environment assignments: FOO=bar git push
+        while [[ ${#TOKENS[@]} -gt 0 && "${TOKENS[0]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+            TOKENS=("${TOKENS[@]:1}")
+            changed=1
+        done
+
+        [[ ${#TOKENS[@]} -gt 0 ]] || break
+
+        case "$(basename -- "${TOKENS[0]}")" in
+            sudo|doas)
+                TOKENS=("${TOKENS[@]:1}")
+                changed=1
+                # Consume sudo flags; -u/-g/-C/-p take a separate argument.
+                while [[ ${#TOKENS[@]} -gt 0 && "${TOKENS[0]}" == -* ]]; do
+                    case "${TOKENS[0]}" in
+                        -u|-g|-C|-p|-h|-r|-t|--user|--group|--prompt)
+                            TOKENS=("${TOKENS[@]:2}")
+                            ;;
+                        *)
+                            TOKENS=("${TOKENS[@]:1}")
+                            ;;
+                    esac
+                done
+                ;;
+            env)
+                TOKENS=("${TOKENS[@]:1}")
+                changed=1
+                while [[ ${#TOKENS[@]} -gt 0 && "${TOKENS[0]}" == -* ]]; do
+                    TOKENS=("${TOKENS[@]:1}")
+                done
+                ;;
+            nice|ionice|nohup|stdbuf|time|command|builtin|exec)
+                TOKENS=("${TOKENS[@]:1}")
+                changed=1
+                while [[ ${#TOKENS[@]} -gt 0 && "${TOKENS[0]}" == -* ]]; do
+                    TOKENS=("${TOKENS[@]:1}")
+                done
+                ;;
+        esac
+    done
+}
+
+# ---------------------------------------------------------------------------
+# git policy
+# ---------------------------------------------------------------------------
+
+# git subcommands that always write to the current branch or the remote.
+git_subcommand_always_writes() {
+    case "$1" in
+        commit|push|merge|rebase|cherry-pick|revert|am|filter-branch|update-ref|fast-import)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+# Returns 0 (block) if this `git reset` invocation moves the branch pointer or
+# destroys the working tree. `git reset -- path` and bare `git reset` only touch
+# the index and are allowed.
+git_reset_writes() {
+    local -a args=("$@")
+    local arg
+    for arg in "${args[@]}"; do
+        case "$arg" in
+            --hard|--merge|--keep|--soft)
+                return 0
+                ;;
+            --)
+                # Path-limited unstage: git reset -- file
+                return 1
+                ;;
+        esac
+    done
+    # A bare commit-ish argument (git reset HEAD~1) moves the branch pointer.
+    for arg in "${args[@]}"; do
+        [[ "$arg" == -* ]] && continue
+        return 0
+    done
+    return 1
+}
+
+# Returns 0 (block) for branch deletion, forced creation or renaming. Plain
+# listing and ordinary branch creation are harmless.
+git_branch_writes() {
+    local arg
+    for arg in "$@"; do
+        case "$arg" in
+            -D|-d|--delete|-f|--force|-M|-m|--move|-C|--copy|--edit-description)
+                return 0
+                ;;
+        esac
+    done
+    return 1
+}
+
+# Returns 0 (block) if checkout/switch moves HEAD off the protected branch or
+# force-resets a branch ref.
+#
+# `git checkout -b` / `git switch -c` are deliberately ALLOWED: creating a
+# feature branch is the remedy this hook's own deny message instructs the user
+# to perform, so blocking it would trap them on the protected branch. The
+# force variants (-B / -C) can reset an existing branch ref and stay blocked.
+git_checkout_writes() {
+    local arg
+    for arg in "$@"; do
+        case "$arg" in
+            -B|--force-create)
+                return 0
+                ;;
+            -b|-c|--create)
+                return 1
+                ;;
+            --)
+                # Path restore: git checkout -- file. Does not move HEAD.
+                return 1
+                ;;
+        esac
+    done
+    # A bare ref argument moves HEAD.
+    for arg in "$@"; do
+        [[ "$arg" == -* ]] && continue
+        return 0
+    done
+    return 1
+}
+
+# Inspect a git invocation. TOKENS[0] is known to be git.
+# Echoes a human-readable reason and returns 0 when the call must be blocked.
+inspect_git() {
+    local -a args=("${@:2}")
+
+    # Skip global options to find the subcommand. Options taking a value are
+    # consumed with their argument.
+    local subcommand="" idx=0
+    while [[ $idx -lt ${#args[@]} ]]; do
+        case "${args[idx]}" in
+            -C|-c|--git-dir|--work-tree|--namespace|--exec-path)
+                idx=$((idx + 2))
+                ;;
+            --git-dir=*|--work-tree=*|--namespace=*|--exec-path=*)
+                idx=$((idx + 1))
+                ;;
+            -*)
+                idx=$((idx + 1))
+                ;;
+            *)
+                subcommand="${args[idx]}"
+                break
+                ;;
+        esac
+    done
+
+    [[ -n "$subcommand" ]] || return 1
+
+    local -a subargs=()
+    if [[ $((idx + 1)) -lt ${#args[@]} ]]; then
+        subargs=("${args[@]:idx+1}")
+    fi
+
+    if git_subcommand_always_writes "$subcommand"; then
+        echo "git $subcommand writes to the branch or remote"
+        return 0
+    fi
+
+    case "$subcommand" in
+        reset)
+            if git_reset_writes "${subargs[@]+"${subargs[@]}"}"; then
+                echo "git reset moves the branch pointer or discards the working tree"
+                return 0
+            fi
+            ;;
+        branch)
+            if git_branch_writes "${subargs[@]+"${subargs[@]}"}"; then
+                echo "git branch deletes, renames or force-updates a branch ref"
+                return 0
+            fi
+            ;;
+        checkout|switch)
+            if git_checkout_writes "${subargs[@]+"${subargs[@]}"}"; then
+                echo "git $subcommand moves HEAD off the protected branch"
+                return 0
+            fi
+            ;;
+    esac
+
+    return 1
+}
+
+# Detect writes that bypass git entirely by editing files under .git/.
+WRITE_COMMANDS="rm|mv|cp|tee|dd|truncate|ln|install|shred|sed|perl|chmod|chown"
+inspect_git_dir_write() {
+    local raw="$1"
+    shift
+    local -a args=("$@")
+
+    local cmd
+    cmd="$(basename -- "${args[0]:-}")"
+
+    # Redirection into .git/ regardless of the command driving it.
+    if [[ "$raw" =~ \>\>?[[:space:]]*[^[:space:]]*\.git/ ]]; then
+        echo "shell redirection writes under .git/"
+        return 0
+    fi
+
+    if [[ "$cmd" =~ ^($WRITE_COMMANDS)$ ]]; then
+        local arg
+        for arg in "${args[@]}"; do
+            if [[ "$arg" == .git/* || "$arg" == */.git/* || "$arg" == .git || "$arg" == */.git ]]; then
+                echo "$cmd writes under .git/"
+                return 0
+            fi
+        done
+    fi
+
+    return 1
+}
+
+# Analyse one segment. Returns 0 with a reason on stdout when it must block.
+inspect_segment() {
+    local segment="$1"
+    local depth="${2:-0}"
+
+    tokenize "$segment"
+    [[ ${#TOKENS[@]} -gt 0 ]] || return 1
+
+    strip_wrappers
+    [[ ${#TOKENS[@]} -gt 0 ]] || return 1
+
+    local cmd
+    cmd="$(basename -- "${TOKENS[0]}")"
+
+    # Recurse one level into `sh -c '...'` so that a wrapped `git push` is still
+    # caught, while `sh -c 'tar ... | ssh ...'` remains allowed on its merits.
+    if [[ "$cmd" =~ ^(sh|bash|zsh|dash|ksh)$ && $depth -lt 2 ]]; then
+        local i
+        for ((i = 1; i < ${#TOKENS[@]}; i++)); do
+            if [[ "${TOKENS[i]}" == "-c" && $((i + 1)) -lt ${#TOKENS[@]} ]]; then
+                local inner="${TOKENS[i + 1]}"
+                local -a saved=("${TOKENS[@]}")
+                local reason
+                if reason="$(inspect_command "$inner" $((depth + 1)))"; then
+                    echo "$reason"
+                    return 0
+                fi
+                TOKENS=("${saved[@]}")
+                break
+            fi
+        done
+    fi
+
+    local reason
+    if reason="$(inspect_git_dir_write "$segment" "${TOKENS[@]}")"; then
+        echo "$reason"
+        return 0
+    fi
+
+    if [[ "$cmd" == "git" ]]; then
+        if reason="$(inspect_git "${TOKENS[@]}")"; then
+            echo "$reason"
+            return 0
+        fi
+    fi
+
+    # Every other command - openssl, curl, tar, ssh, make, read-only git - passes.
+    return 1
+}
+
+# Analyse a full command string across all its segments.
+inspect_command() {
+    local command="$1"
+    local depth="${2:-0}"
+
+    local -a segments
+    split_segments "$command"
+    segments=("${SEGMENTS[@]}")
+
+    local segment reason
+    for segment in "${segments[@]}"; do
+        [[ -n "${segment//[[:space:]]/}" ]] || continue
+        if reason="$(inspect_segment "$segment" "$depth")"; then
+            echo "$reason"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
 log_debug "Hook script started"
 log_debug "Working directory: $(pwd)"
 
@@ -80,28 +523,26 @@ if [[ ! "$CURRENT_BRANCH" =~ $PROTECTED_PATTERN ]]; then
     allow
 fi
 
-log_error "PROTECTED BRANCH VIOLATION: Attempt to use tool '$TOOL_NAME' on protected branch '$CURRENT_BRANCH'"
+# Bash is judged on what the command actually does. Edit, Write and Task modify
+# files directly and stay unconditionally blocked on a protected branch.
+if [[ "$TOOL_NAME" == "Bash" ]]; then
+    COMMAND=$(echo "$STDIN_CONTENT" | jq -r '.tool_input.command // empty')
 
-deny "Direct edits to protected branch '$CURRENT_BRANCH' are not allowed.
+    if [[ -z "$COMMAND" ]]; then
+        log_warn "Bash tool with no command field, allowing"
+        allow
+    fi
 
-Protected branches enforce PR-based workflows to ensure:
-- Code review and quality standards
-- CI/CD pipeline validation
-- Collaboration and knowledge sharing
-- Audit trail for all changes
+    log_debug "Inspecting command: $COMMAND"
 
-To proceed:
-1. Create a feature branch:
-   git checkout -b your-name/feature-description
+    # Fail OPEN on anything unparseable. A blanket deny on commands the parser
+    # cannot understand is the exact failure mode this rewrite exists to fix.
+    if ! REASON="$(inspect_command "$COMMAND" 2>/dev/null)"; then
+        log_info "Command is read-only or non-git, allowing: $COMMAND"
+        allow
+    fi
 
-2. Make your changes on the feature branch
+    deny_branch_write "$REASON"
+fi
 
-3. Push and create a Pull Request:
-   git push -u origin your-name/feature-description
-
-Protected branches: ${PROTECTED_BRANCHES[*]}
-
-For emergency changes, use the override environment variable:
-ALLOW_PROTECTED_BRANCH_EDIT=1
-
-This hook ensures repository safety and collaboration best practices."
+deny_branch_write "the $TOOL_NAME tool modifies files directly"

--- a/tests/test-protect-main-branch.sh
+++ b/tests/test-protect-main-branch.sh
@@ -77,9 +77,60 @@ EOF
 echo "Running Protected Branch Hook Tests..."
 echo "========================================"
 
+run_bash_test() {
+    local test_name="$1"
+    local branch="$2"
+    local command="$3"
+    local should_block="$4"
+
+    local tmpfile
+    tmpfile=$(mktemp)
+
+    jq -n --arg cmd "$command" '{
+      hook_event_name: "PreToolUse",
+      tool_name: "Bash",
+      tool_input: { command: $cmd }
+    }' > "$tmpfile"
+
+    local output
+    local exit_code=0
+
+    if output=$(TEST_BRANCH_NAME="$branch" CLAUDE_PROJECT_DIR="$PROJECT_ROOT" \
+        bash "$HOOK_SCRIPT" < "$tmpfile" 2>&1); then
+        exit_code=0
+    else
+        exit_code=$?
+    fi
+
+    rm -f "$tmpfile"
+
+    if [[ $exit_code -ne 0 ]]; then
+        test_failed "$test_name (hook exited $exit_code, expected 0)"
+        return
+    fi
+
+    local decision=""
+    if [[ -n "$output" ]]; then
+        decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null || echo "")
+    fi
+
+    if [[ "$should_block" == "true" ]]; then
+        if [[ "$decision" == "deny" ]]; then
+            test_passed "$test_name"
+        else
+            test_failed "$test_name (expected deny, got '${decision:-no decision}')"
+        fi
+    else
+        if [[ -z "$decision" ]]; then
+            test_passed "$test_name"
+        else
+            test_failed "$test_name (expected allow, got '$decision')"
+        fi
+    fi
+}
+
 run_test "Block Edit on main branch" "main" "Edit" "true"
 run_test "Block Write on main branch" "main" "Write" "true"
-run_test "Block Bash on main branch" "main" "Bash" "true"
 run_test "Block Task on main branch" "main" "Task" "true"
 
 run_test "Block Edit on master branch" "master" "Edit" "true"
@@ -93,6 +144,84 @@ run_test "Allow Task on feature branch" "carol/test-workflow" "Task" "false"
 
 run_test "Allow Read on main branch" "main" "Read" "false"
 run_test "Allow Grep on main branch" "main" "Grep" "false"
+
+echo ""
+echo "--- Regression: read-only and non-git Bash on main (was wrongly blocked) ---"
+
+# Every one of these was denied by the pre-fix hook, which never read
+# tool_input.command and blocked all Bash on a protected branch outright.
+run_bash_test "Allow openssl s_client cert inspection" "main" \
+    "echo | openssl s_client -connect h:443 -servername h | openssl x509 -noout -issuer" "false"
+run_bash_test "Allow curl piped into grep" "main" \
+    "curl -sSv https://h/p 2>&1 | grep -iE 'issuer:|subject:'" "false"
+run_bash_test "Allow git status --short" "main" "git status --short" "false"
+run_bash_test "Allow git diff on a path" "main" "git diff path/to/file" "false"
+run_bash_test "Allow sudo sh -c tar piped to ssh" "main" \
+    "sudo sh -c 'tar c -C /d a b | ssh -i key user@host'" "false"
+
+run_bash_test "Allow curl piped into head" "main" "curl -sSI https://h/p | head -1" "false"
+run_bash_test "Allow git add -N / reset -- / diff --cached" "main" \
+    "git add -N file ; git reset -- file ; git diff --cached --name-only" "false"
+
+echo ""
+echo "--- Regression: read-only git and lookalike strings ---"
+
+run_bash_test "Allow git log" "main" "git log --oneline -5" "false"
+run_bash_test "Allow git show" "main" "git show HEAD --stat" "false"
+run_bash_test "Allow git blame" "main" "git blame README.md" "false"
+run_bash_test "Allow git fetch" "main" "git fetch origin" "false"
+run_bash_test "Allow git branch listing" "main" "git branch -a" "false"
+run_bash_test "Allow plain find" "main" "find . -name '*.sh' -not -path './.git/*'" "false"
+# Dangerous-looking tokens that are only ever data, never a git write.
+run_bash_test "Allow grep for the word push" "main" "grep -rn 'push' plugins/" "false"
+run_bash_test "Allow echo mentioning git commit" "main" "echo 'run git commit later'" "false"
+run_bash_test "Allow URL containing main and push" "main" \
+    "curl -s https://example.com/main/push | wc -l" "false"
+run_bash_test "Allow reading a file under .git" "main" "cat .git/HEAD" "false"
+
+echo ""
+echo "--- Genuine protected-branch writes must still be blocked ---"
+
+run_bash_test "Block git commit" "main" "git commit -m 'change'" "true"
+run_bash_test "Block git commit -am" "main" "git commit -am 'change'" "true"
+run_bash_test "Block git push" "main" "git push" "true"
+run_bash_test "Block git push origin main" "main" "git push origin main" "true"
+run_bash_test "Block git merge" "main" "git merge feature/x" "true"
+run_bash_test "Block git rebase" "main" "git rebase origin/main" "true"
+run_bash_test "Block git cherry-pick" "main" "git cherry-pick abc123" "true"
+run_bash_test "Block git revert" "main" "git revert HEAD" "true"
+run_bash_test "Block git reset --hard" "main" "git reset --hard HEAD~1" "true"
+run_bash_test "Block git reset to a commit-ish" "main" "git reset HEAD~1" "true"
+run_bash_test "Block git branch -D" "main" "git branch -D old-feature" "true"
+run_bash_test "Block git branch -f" "main" "git branch -f main abc123" "true"
+run_bash_test "Block git checkout -B" "main" "git checkout -B main origin/main" "true"
+run_bash_test "Block git switch to another branch" "main" "git switch other" "true"
+run_bash_test "Block git update-ref" "main" "git update-ref refs/heads/main abc123" "true"
+
+echo ""
+echo "--- Writes hidden behind wrappers, pipelines and .git/ ---"
+
+run_bash_test "Block git commit behind sudo" "main" "sudo git commit -m x" "true"
+run_bash_test "Block git push behind env assignment" "main" "GIT_AUTHOR_NAME=x git push" "true"
+run_bash_test "Block git push wrapped in sh -c" "main" "sh -c 'git push origin main'" "true"
+run_bash_test "Block git commit later in a pipeline" "main" "echo hi && git commit -m x" "true"
+run_bash_test "Block git commit with -C global option" "main" "git -C /repo commit -m x" "true"
+run_bash_test "Block rm under .git/" "main" "rm -f .git/refs/heads/main" "true"
+run_bash_test "Block redirection into .git/" "main" "echo abc123 > .git/refs/heads/main" "true"
+
+echo ""
+echo "--- Feature branches are unaffected regardless of command ---"
+
+run_bash_test "Allow git push on feature branch" "feature/test" "git push origin feature/test" "false"
+run_bash_test "Allow git commit on feature branch" "alice/PROJ-1" "git commit -m 'work'" "false"
+
+echo ""
+echo "--- Creating a feature branch is the remedy and must be allowed ---"
+
+# The deny message instructs the user to run exactly this; blocking it would
+# trap them on the protected branch with no sanctioned way off.
+run_bash_test "Allow git checkout -b" "main" "git checkout -b alice/new-feature" "false"
+run_bash_test "Allow git switch -c" "main" "git switch -c alice/new-feature" "false"
 
 # The deny payload must be parseable JSON: the previous heredoc embedded raw
 # newlines in a string literal, which no JSON parser accepts.
@@ -111,6 +240,15 @@ if [[ -z "$override_output" ]]; then
     test_passed "ALLOW_PROTECTED_BRANCH_EDIT bypasses protection"
 else
     test_failed "ALLOW_PROTECTED_BRANCH_EDIT bypasses protection"
+fi
+
+bash_override_output=$(jq -n '{tool_name:"Bash",tool_input:{command:"git push origin main"}}' |
+    TEST_BRANCH_NAME="main" CLAUDE_PROJECT_DIR="$PROJECT_ROOT" \
+    ALLOW_PROTECTED_BRANCH_EDIT=1 bash "$HOOK_SCRIPT")
+if [[ -z "$bash_override_output" ]]; then
+    test_passed "ALLOW_PROTECTED_BRANCH_EDIT bypasses protection for Bash writes"
+else
+    test_failed "ALLOW_PROTECTED_BRANCH_EDIT bypasses protection for Bash writes"
 fi
 
 echo ""


### PR DESCRIPTION
## Problem

The protected-branch hook read only `.tool_name` and never read `tool_input.command`. The entire decision was:

```
tool ∈ {Edit, Write, Bash, Task} AND branch ∈ {main, master, production, release} → deny
```

On a protected branch every Bash call was therefore denied — a bare `ls` as surely as `git push`. Read-only commands and commands with no git involvement at all were blocked:

- `echo | openssl s_client -connect h:443 -servername h | openssl x509 -noout -issuer`
- `curl -sSv https://h/p 2>&1 | grep -iE 'issuer:|subject:'`
- `git status --short`
- `git diff path/to/file`
- `sudo sh -c 'tar c -C /d a b | ssh -i key user@host'`

This was not an over-broad regex or a fail-closed parse path. There was no parsing at all.

## Change

Bash is now decided on parsed argv, never on substring matches against the raw command string:

- Quote-aware splitter over unquoted `| ; & \n`, so separators inside quotes don't fragment a segment.
- Tokenizer plus wrapper stripping: leading `VAR=val` assignments and `sudo`/`doas`/`env`/`nice`/`nohup`/`time`, including their value-taking flags.
- **Non-git commands pass unconditionally.**
- git policy keys off the subcommand token, located after skipping global options so `git -C /repo commit` is caught. Always blocks `commit`, `push`, `merge`, `rebase`, `cherry-pick`, `revert`, `am`, `filter-branch`, `update-ref`, `fast-import`. Conditionally blocks destructive `reset`, `branch` delete/force/rename, and HEAD-moving `checkout`/`switch`.
- One level of recursion into `sh -c '…'`, so `sh -c 'git push'` is caught while the tar/ssh pipe is not.
- Writes under `.git/` via `rm`/`mv`/`tee`/`sed` and friends, or shell redirection.

`Edit`, `Write` and `Task` keep their unconditional block on protected branches. `ALLOW_PROTECTED_BRANCH_EDIT` is unchanged.

### `git checkout -b` and `git switch -c` are allowed

`-b` creates a new ref and moves HEAD onto it. It does not touch the protected branch. It is also the exact command the hook's own deny message instructs the user to run, so blocking it would leave them on the protected branch with no sanctioned way off.

`-B` is a different command: where `-b` fails if the branch already exists, `-B` resets it to the start point. `git checkout -B main origin/main` is a protected-branch write with no commit, push or merge involved. The line is drawn at "can this clobber an existing ref", not at "does this move HEAD". `-b`/`-c` allowed, `-B`/`-C` blocked.

### Parse failures fail open

Anything the parser cannot read is logged and allowed. A blanket deny on unparseable input is the failure this PR exists to fix.

## Tests

`run_test "Block Bash on main branch" "main" "Bash" "true"` is removed. It asserted the bug as correct behaviour and passed `tool_input: {}`, so no test in the file ever exercised a command string.

46 cases added:

- The reported false positives, and read-only git (`status`, `diff`, `log`, `show`, `blame`, `fetch`, `branch -a`).
- Lookalike strings that would catch a regression to substring matching: `grep -rn 'push'`, a URL containing `main/push`, `echo 'run git commit later'`, `cat .git/HEAD`.
- Genuine writes: `git commit`, `git push`, `git merge`, `git rebase`, `git reset --hard`, `git branch -D`, `git checkout -B`, `git update-ref`.
- Writes hidden behind `sudo`, env assignments, `sh -c`, pipelines, and `git -C`.
- Both sides of the `-b` / `-B` distinction, and the override on the Bash path.

## CI

Adds a `Tests` workflow running `make test` on pushes to `main` and PRs targeting `main`, matching the existing linter triggers. The repo linted PRs but never ran the suite, so a regression in the hooks could merge green.

Explicit `*)` branches added to the case statements in the hook: `.github/linters/.shellcheckrc` sets `enable=add-default-case`, and each default documents that falling through means "allow".

## Release

Bumps `security-hooks` to **1.1.0** in `plugin.json` and `marketplace.json`.

The plugin cache is keyed by version (`~/.claude/plugins/cache/claude-code-template/security-hooks/1.0.0/`). While the manifest stayed at 1.0.0 the cache was never invalidated, so reinstalling or reloading the plugin kept serving the original 1.0.0 payload — which predates #42, reads `.tool` instead of `.tool_name`, and therefore exits 0 on every call. Any install still on a cached 1.0.0 has branch protection that silently allows everything.

Without the bump, neither this fix nor #42/#43 reaches installs.
