### PR TITLE
refactor(git-workflow): migrate to skills, tighten message rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Migrated the `git-workflow` plugin from commands to the skill format
+  (`skills/<name>/SKILL.md`)
+- Tightened `git-workflow` commit and PR message rules: no emoji, shorter bodies
 - Improved project linting and code quality standards
 - Enhanced security scanning capabilities
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ Legacy slash commands (still functional):
 
 - `/check` - Comprehensive code quality analysis and auto-fix with parallel sub-task strategy
 - `/clean` - Remove redundant and obvious comments from codebase
-- `/changelog` - Create and maintain project changelog following Keep a Changelog format
+- `/git-workflow:changelog` - Create and maintain project changelog following Keep a Changelog format (migrated to a skill in the `git-workflow` plugin)
 
 ## Architecture
 
@@ -113,7 +113,7 @@ The scanner detects multiple categories of sensitive data:
 4. **Hook Testing**: Test security patterns with sample MCP requests as shown in the documentation
 5. **Quality Checks**: Use `/check` command for comprehensive code quality analysis and auto-fixing
 6. **Code Cleanup**: Use `/clean` command to remove redundant comments before commits
-7. **Changelog**: Use `/changelog` command to maintain project changelog with proper versioning
+7. **Changelog**: Use `/git-workflow:changelog` to maintain project changelog with proper versioning
 
 ## Hook System Architecture
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ make test
 
 ### GitHub Workflow
 
-- `/gh:commit` - Creates conventional commits with emoji
+- `/gh:commit` - Creates brief conventional commits
 - `/gh:pr` - Creates GitHub pull requests with templates
 
 ### Project Management

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ make test
 
 ### GitHub Workflow
 
-- `/gh:commit` - Creates brief conventional commits
-- `/gh:pr` - Creates GitHub pull requests with templates
+- `/git-workflow:commit` - Creates brief conventional commits
+- `/git-workflow:pr` - Creates draft GitHub pull requests from the branch
 
 ### Project Management
 
@@ -79,7 +79,7 @@ make test
 
 ### Documentation
 
-- `/changelog` - Maintains CHANGELOG.md following Keep a Changelog format
+- `/git-workflow:changelog` - Maintains CHANGELOG.md following Keep a Changelog format
 - `/promptify` - Generates high-quality AI prompts with best practices
 - `/prompt-reviewer` - Reviews and improves AI prompts
 
@@ -109,7 +109,7 @@ make status         # Show configuration and tool status
 plugins/                          # Marketplace plugin distribution
 ├── security-hooks/              # MCP security and branch protection
 ├── dev-skills/                  # Development skills (Go, docs, etc.)
-├── git-workflow/                # Git automation commands
+├── git-workflow/                # Git automation skills
 ├── pm-tools/                    # Project management commands
 ├── code-quality/                # Code review and cleanup
 └── prompt-tools/                # AI prompt generation

--- a/docs/MARKETPLACE.md
+++ b/docs/MARKETPLACE.md
@@ -89,9 +89,9 @@ claude code plugins install dev-skills
 
 **Components**:
 
-- `/commit` - Conventional commits with emoji
-- `/pr` - GitHub pull request creation
-- `/changelog` - Changelog maintenance
+- `/git-workflow:commit` - Brief conventional commits
+- `/git-workflow:pr` - GitHub pull request creation
+- `/git-workflow:changelog` - Changelog maintenance
 
 **Features**:
 

--- a/plugins/git-workflow/.claude-plugin/plugin.json
+++ b/plugins/git-workflow/.claude-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "git-workflow",
-  "description": "Git workflow automation commands for commits, PRs, and changelog management",
-  "version": "1.0.0",
+  "description": "Git workflow automation skills for commits, PRs, and changelog management",
+  "version": "2.0.0",
   "author": {
     "name": "Richard Claydon"
   },
   "license": "MPL-2.0",
   "keywords": ["git", "github", "workflow", "changelog"],
-  "commands": ["./commands/"]
+  "skills": ["./skills/"]
 }

--- a/plugins/git-workflow/README.md
+++ b/plugins/git-workflow/README.md
@@ -6,14 +6,14 @@ Git workflow automation commands for commits, PRs, and changelog management.
 
 ### `/commit`
 
-Creates well-formatted commits with conventional commit messages and emoji.
+Creates commits with brief conventional commit messages.
 
 **Features**:
 
-- Conventional commit format (feat, fix, docs, etc.)
-- Optional emoji prefixes
+- Conventional commit format (feat, fix, docs, etc.), no emoji
+- Subject-only messages by default; body only when the diff cannot explain the change
 - Automatic commit message generation from staged changes
-- Follows repository commit message style
+- Suggests splitting when staged changes mix concerns
 
 ### `/pr`
 
@@ -22,8 +22,8 @@ Creates a PR on GitHub with proper title and description.
 **Features**:
 
 - Analyzes full commit history for the branch
-- Generates concise PR title (under 70 characters)
-- Creates detailed PR description with summary and test plan
+- Generates a concise PR title (under 70 characters, no emoji)
+- Writes a succinct description covering only what the branch changes
 - Automatically pushes branch if needed
 
 ### `/changelog`

--- a/plugins/git-workflow/README.md
+++ b/plugins/git-workflow/README.md
@@ -1,10 +1,10 @@
 # Git Workflow Plugin
 
-Git workflow automation commands for commits, PRs, and changelog management.
+Git workflow automation skills for commits, PRs, and changelog management.
 
-## Commands Included
+## Skills Included
 
-### `/commit`
+### `/git-workflow:commit`
 
 Creates commits with brief conventional commit messages.
 
@@ -15,7 +15,7 @@ Creates commits with brief conventional commit messages.
 - Automatic commit message generation from staged changes
 - Suggests splitting when staged changes mix concerns
 
-### `/pr`
+### `/git-workflow:pr`
 
 Creates a PR on GitHub with proper title and description.
 
@@ -26,7 +26,7 @@ Creates a PR on GitHub with proper title and description.
 - Writes a succinct description covering only what the branch changes
 - Automatically pushes branch if needed
 
-### `/changelog`
+### `/git-workflow:changelog`
 
 Maintains a CHANGELOG.md document following Keep a Changelog format.
 
@@ -55,17 +55,20 @@ claude code plugins install github:rikdc/claude_code_template/git-workflow
 
 ```bash
 # Create a commit
-/commit
+/git-workflow:commit
 
-# Create a commit with specific message
-/commit -m "feat: add user authentication"
+# Create a commit, skipping pre-commit checks
+/git-workflow:commit --no-verify
 
-# Create a pull request
-/pr
+# Create a draft pull request
+/git-workflow:pr
 
-# Update changelog
-/changelog Add new authentication feature to version 1.2.0
+# Add a changelog entry
+/git-workflow:changelog --add-entry "Add user authentication" --type added
 ```
+
+Each skill also triggers on plain requests such as "commit this" or "open a
+PR" — the slash form is just the explicit way to invoke it.
 
 ## License
 

--- a/plugins/git-workflow/commands/commit.md
+++ b/plugins/git-workflow/commands/commit.md
@@ -1,89 +1,99 @@
 ---
 allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*), Bash(git diff:*), Bash(git log:*)
-description: Creates well-formatted commits with conventional commit messages
+description: Creates brief conventional-commit messages
 ---
 
 # Claude Command: Commit
 
-Creates well-formatted commits with conventional commit messages.
-Runs pre-commit checks and suggests commit splitting when appropriate.
+Creates commits with short conventional commit messages. Runs pre-commit checks
+and suggests splitting when the staged changes cover more than one concern.
 
 ## Usage
 
-To create a commit, just type:
-
 ```bash
 /commit [--no-verify] [--help]
-
 ```
 
 ## Workflow
 
-This command spawns parallel sub-tasks for efficiency:
+1. **Pre-commit checks** (unless `--no-verify`): run `make checks` if available.
+2. **Git analysis**: inspect staged files and `git diff` to identify the change.
+3. **Commit**: write the message, then commit.
 
-1. **Pre-commit checks** (unless `--no-verify`): Runs `make checks` if available.
-2. **Git analysis**: Checks staged files, runs `git diff`, analyzes change patterns
-3. **Commit preparation**: Generates conventional commit messages. Omit emoji from commit messages.
+If nothing is staged, stage all modified files. If the diff covers distinct
+concerns, propose atomic commits before committing.
 
-If no files are staged, automatically stages all modified files.
-If multiple distinct changes are detected, suggests splitting into atomic commits.
-
-## Core Commit Types
-
-- `feat`: New feature
-- `fix`: Bug fix
-- `docs`: Documentation
-- `style`: Formatting/style
-- `refactor`: Code refactoring
-- `perf`: Performance improvements
-- `test`: Tests
-- `chore`: Tooling, configuration
-- `ci`: CI/CD improvements
-- `fix`: Fix compiler/linter warnings
-- `fix`: Security fixes
-- `fix`: Simple non-critical fixes
-
-## Commit Message Format
-
-```markdown
-<type>: <description>
-[optional body]
+## Message Rules
 
 ```
+<type>(<scope>): <subject>
 
-- Use present tense, imperative mood ("add feature" not "added feature")
-- Keep first line under 72 characters
-- Each commit should contain related changes serving a single purpose
+[body — only when required]
+```
+
+- **No emoji.** Not in the subject, not in the body.
+- Subject: imperative mood, lower case, no trailing period, under 60 characters.
+- `scope` is optional; include it only when it disambiguates.
+- **Default to a subject line alone.** Most commits need nothing more.
+- Add a body only for information the diff cannot show: why the change was
+  made, a breaking change, or an issue reference. Cap it at two short sentences
+  or three bullets.
+- Never restate the diff, list touched files, summarise your process, or add
+  closing commentary.
+
+## Types
+
+- `feat`: new feature
+- `fix`: bug fix, security fix, warning fix
+- `docs`: documentation
+- `style`: formatting
+- `refactor`: restructuring without behaviour change
+- `perf`: performance
+- `test`: tests
+- `chore`: tooling, dependencies, configuration
+- `ci`: CI/CD
 
 ## Splitting Criteria
 
-Suggests multiple commits when changes involve:
-
-- Different concerns or file types
-- Mixed change types (feature + fix + docs)
-- Large changes that would be clearer when separated
+Propose separate commits when the staged changes mix concerns, mix types
+(feature + fix + docs), or are large enough that one message cannot describe
+them accurately.
 
 ## Examples
 
-Good commit messages:
+Good:
 
-- feat: add user authentication system
-- fix: resolve memory leak in rendering process
-- docs: update API documentation with new endpoints
-- refactor: simplify error handling logic
+- `feat(auth): add session refresh endpoint`
+- `fix(render): release texture handles on unmount`
+- `docs: document the scanner exit codes`
+- `refactor: collapse duplicate error wrapping`
 
-Example split:
+With a body, where the reason is not visible in the diff:
 
-- feat: add new API endpoints
-- docs: update API documentation
-- test: add unit tests for new endpoints
+```
+fix(scanner): match patterns case-insensitively
+
+Uppercase AWS keys were slipping through, reported in #212.
+```
+
+Too verbose — do not do this:
+
+```
+✨ feat(auth): add a new session refresh endpoint to the auth package
+
+This commit adds a new endpoint. It modifies auth/handler.go to add the
+handler, auth/routes.go to register the route, and auth/handler_test.go to
+cover it. This improves the developer experience and makes the codebase
+more maintainable going forward.
+```
 
 ## Options
 
-- `--no-verify`: Skip pre-commit checks
+- `--no-verify`: skip pre-commit checks
+- `--help`: show this reference
 
 ## Notes
 
-- **Pre-commit failures**: Prompts to fix issues or proceed anyway
-- **No staged files**: Auto-stages all modified/new files
-- **Large changes**: Suggests atomic commits with guided staging
+- **Pre-commit failures**: ask whether to fix or proceed.
+- **No staged files**: auto-stage modified and new files.
+- **Large changes**: suggest atomic commits with guided staging.

--- a/plugins/git-workflow/commands/pr.md
+++ b/plugins/git-workflow/commands/pr.md
@@ -5,107 +5,94 @@ description: Creates a PR on GitHub
 
 # GitHub PR Creation Assistant
 
-Creates a new GitHub pull request using our project template and conventions.
+Creates a draft pull request with a conventional-commit title and a short
+description of what the branch actually changes.
 
-## Usage
+## Workflow
 
-This command will:
+1. **Validate**: `gh auth status`, current branch, uncommitted changes.
+2. **Read the branch**: `git log <base>..HEAD` and `git diff <base>...HEAD` —
+   the description covers exactly this, nothing more.
+3. **Write the body**: use `.github/pull_request_template.md` if present,
+   otherwise the sections below.
+4. **Create**: `gh pr create --draft --title "<type>(<scope>): <subject>" --body-file <file> --base main`
 
-1. Check git status and GitHub CLI authentication
-2. Retrieve and populate the PR template
-3. Format title using conventional commits
-4. Create draft PR with proper structure
+## Title Rules
 
-## Command Structure
+- Conventional commit format: `<type>(<scope>): <subject>`.
+- **No emoji.** The title is plain text.
+- Under 70 characters, imperative mood, no trailing period.
+- For a single-commit PR, reuse that commit's subject.
 
-```bash
-gh pr create --draft --title "✨(scope): Your descriptive title" --body-file .github/pull_request_template.md --base main
+Examples:
 
-```
+- `feat(auth): add session refresh endpoint`
+- `fix(scanner): match patterns case-insensitively`
+- `docs: document the scanner exit codes`
 
-### Title Format
+## Body Rules
 
-Use conventional commit format with emojis:
+Keep it succinct. The PR body describes the commits on the branch and nothing
+else.
 
-✨(feature): Add new functionality
-🐛(bugfix): Fix critical issue
-📝(docs): Update documentation
-🔧(config): Modify configuration
+- **Summary**: one to three sentences. What changed and why. No restating the
+  title, no background essay.
+- **Changes**: one bullet per meaningful change, one line each. Group trivial
+  edits rather than listing every file. Under six bullets for a normal PR — if
+  it needs more, the PR is probably too large.
+- **Testing**: one line stating what was run (`make test`, `go test ./...`) and
+  the result. Say so plainly if nothing was run.
+- Drop any template section that has nothing real to say.
+- No emoji, no headings beyond the template's, no "Notes for reviewers",
+  "Future work", "Impact", or risk-assessment sections unless asked.
+- Do not claim behaviour you have not verified.
 
-### Workflow Steps
-
-Sub-task 1: Validation
-
-- Verify GitHub CLI installation and authentication
-- Check current branch status
-- Validate uncommitted changes
-
-### Sub-task 2: Template Processing
-
-- Read .github/pull_request_template.md
-- Pre-populate known sections
-- Validate template structure
-
-### Sub-task 3: PR Creation
-
-- Format title with appropriate emoji
-- Create draft PR with populated template
-- Set proper base branch and reviewers
-
-### Template Sections
-
-Ensure all sections are included:
+Default body when there is no template:
 
 ```markdown
+## Summary
 
-# Summary
-
-## pr_agent:summary
+<1-3 sentences>
 
 ## Changes
 
-## pr_agent:walkthrough
+- <change>
+- <change>
 
 ## Testing
 
-## Checklist
-
+<command and result>
 ```
 
-Common Actions
+Example body:
+
+```markdown
+## Summary
+
+Pattern matching in the MCP scanner was case-sensitive, so uppercase AWS keys
+passed the scan. Matching is now case-insensitive.
+
+## Changes
+
+- Add `-i` to the pattern grep in `mcp-security-scanner.sh`
+- Cover uppercase keys in `tests/test-scanner.sh`
+
+## Testing
+
+`make test` — all suites pass.
+```
+
+## Common Actions
 
 ```bash
-
-# Convert draft to ready
-
-gh pr ready <PR-NUMBER>
-
-# Add reviewers
-
-gh pr edit <PR-NUMBER> --add-reviewer username1,username2
-
-# Check PR status
-
-gh pr status
-
+gh pr ready <PR-NUMBER>                                    # draft to ready
+gh pr edit <PR-NUMBER> --add-reviewer user1,user2          # add reviewers
+gh pr status                                               # check status
 ```
 
-### Error Handling
+## Error Handling
 
-The command will automatically:
-
-- Install GitHub CLI if missing (with permission)
-- Prompt for authentication if needed
-- Create template if .github/pull_request_template.md doesn't exist
-- Validate title format and suggest corrections
-
-**Prerequisites Check:***
-
-Before execution, validates:
-
-- GitHub CLI installation
-- Repository authentication
-- Clean working directory
-- Valid branch for PR creation
-
-Use `gh auth status` to verify authentication if issues occur.
+- Missing `gh`: prompt to install.
+- Not authenticated: run `gh auth status` and prompt to log in.
+- Missing PR template: use the default body above; do not create the template
+  file unless asked.

--- a/plugins/git-workflow/skills/changelog/SKILL.md
+++ b/plugins/git-workflow/skills/changelog/SKILL.md
@@ -1,19 +1,21 @@
 ---
-allowed-tools: Read(*), Write(CHANGELOG.md), Edit(CHANGELOG.md), Bash(git add:*), Bash(git status:*), Bash(git commit:*)
-description: Maintains a CHANGELOG.md document in this repository
+name: changelog
+description: Creates and maintains CHANGELOG.md in Keep a Changelog format, including adding entries and cutting releases. Use when the user asks to update the changelog, add a changelog entry, or record a release.
+user-invocable: true
+argument-hint: "[--create] [--add-entry \"description\" --type TYPE] [--release X.Y.Z]"
+allowed-tools: Read, Write(CHANGELOG.md), Edit(CHANGELOG.md), Bash(git add:*), Bash(git status:*), Bash(git commit:*), Bash(git log:*)
 ---
 
-# Add Changelog Command
+# Changelog - Keep a Changelog Maintenance
 
-  Create, update, or maintain a comprehensive changelog following industry standards.
+Create, update, or maintain a comprehensive changelog following industry standards.
 
 ## Usage
 
-- `changelog --create` - Create new CHANGELOG.md
-- `changelog --add-entry "description" --type TYPE` - Add new entry
+- `/git-workflow:changelog --create` - Create new CHANGELOG.md
+- `/git-workflow:changelog --add-entry "description" --type TYPE` - Add new entry
   - Types: `added`, `changed`, `deprecated`, `removed`, `fixed`, `security`
-
-- `changelog --release X.Y.Z` - Move unreleased items to new version
+- `/git-workflow:changelog --release X.Y.Z` - Move unreleased items to new version
 
 ## Instructions
 

--- a/plugins/git-workflow/skills/changelog/SKILL.md
+++ b/plugins/git-workflow/skills/changelog/SKILL.md
@@ -3,112 +3,82 @@ name: changelog
 description: Creates and maintains CHANGELOG.md in Keep a Changelog format, including adding entries and cutting releases. Use when the user asks to update the changelog, add a changelog entry, or record a release.
 user-invocable: true
 argument-hint: "[--create] [--add-entry \"description\" --type TYPE] [--release X.Y.Z]"
-allowed-tools: Read, Write(CHANGELOG.md), Edit(CHANGELOG.md), Bash(git add:*), Bash(git status:*), Bash(git commit:*), Bash(git log:*)
+allowed-tools: Read, Write(CHANGELOG.md), Edit(CHANGELOG.md), Bash(date:*), Bash(git add:*), Bash(git status:*), Bash(git commit:*), Bash(git log:*)
 ---
 
 # Changelog - Keep a Changelog Maintenance
 
-Create, update, or maintain a comprehensive changelog following industry standards.
+Maintains CHANGELOG.md in [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+format with [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Usage
 
-- `/git-workflow:changelog --create` - Create new CHANGELOG.md
-- `/git-workflow:changelog --add-entry "description" --type TYPE` - Add new entry
-  - Types: `added`, `changed`, `deprecated`, `removed`, `fixed`, `security`
-- `/git-workflow:changelog --release X.Y.Z` - Move unreleased items to new version
+- `/git-workflow:changelog --create` - Create CHANGELOG.md
+- `/git-workflow:changelog --add-entry "description" --type TYPE` - Add an entry
+- `/git-workflow:changelog --release X.Y.Z` - Cut a release
 
-## Instructions
+With no flags, infer the operation from the request. Categories: `added`,
+`changed`, `deprecated`, `removed`, `fixed`, `security`.
 
-Based on the provided arguments ($ARGUMENTS), perform the appropriate changelog operation:
+## Skeleton
 
-1. **First, analyze the project context:**
-    - Check if CHANGELOG.md already exists
-    - Read package.json for current version info
-    - Review recent commits for unreleased changes
+```markdown
+# Changelog
 
-2. **Changelog Format (Keep a Changelog)**
+All notable changes to this project will be documented in this file.
 
-   ```markdown
-   # Changelog
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-   All notable changes to this project will be documented in this file.
+## [Unreleased]
 
-   The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-   and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [1.2.3] - 2024-01-15
 
-   ## [Unreleased]
-   ### Added
+### Added
 
-   - New features
+- User authentication
+```
 
-   ### Changed
+Category headings exist only where they have entries. Never write a heading
+with a placeholder bullet under it.
 
-   - Changes in existing functionality
+## Operation: --create
 
-   ### Deprecated
+1. Read CHANGELOG.md. If it exists, stop and report it — do not overwrite.
+2. Write the skeleton above with an empty `## [Unreleased]` and no version
+   sections.
+3. Offer to seed it from `git log`, but do not do so unasked.
 
-   - Soon-to-be removed features
+## Operation: --add-entry
 
-   ### Removed
+1. Read CHANGELOG.md; run `--create` first if it is missing.
+2. Reject a `--type` outside the six categories.
+3. Append the entry as a bullet under `## [Unreleased]` and its `### <Type>`
+   heading, adding that heading if absent.
+4. Preserve the existing order of categories and the file's surrounding
+   formatting.
 
-   - Removed features
+## Operation: --release X.Y.Z
 
-   ### Fixed
+Check before writing, and stop with the reason if any fails:
 
-   - Bug fixes
+- `## [Unreleased]` has at least one entry — nothing to release otherwise.
+- `X.Y.Z` does not already appear in the file.
+- `X.Y.Z` is higher than the most recent version present.
 
-   ### Security
+Then:
 
-   - Security improvements
+1. Get today's date with `date +%F`. Do not guess it.
+2. Rename `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD`, keeping its entries.
+3. Insert a fresh empty `## [Unreleased]` above it.
+4. If the file uses link references at the bottom, add one for `X.Y.Z` and
+   repoint `[Unreleased]` to compare against the new tag.
 
-   ```
+Do not tag, commit, or push unless asked.
 
-3. **Version Entries**
+## Entry Style
 
-   ```markdown
-   ## [1.2.3] - 2024-01-15
-   ### Added
-
-   - User authentication system
-   - Dark mode toggle
-   - Export functionality for reports
-
-   ### Fixed
-
-   - Memory leak in background tasks
-   - Timezone handling issues
-
-   ```
-
-4. **Automation Tools**
-
-   ```bash
-   # Generate changelog from git commits
-   npm install -D conventional-changelog-cli
-   npx conventional-changelog -p angular -i CHANGELOG.md -s
-
-   # Auto-changelog
-   npm install -D auto-changelog
-   npx auto-changelog
-   ```
-
-5. **Commit Convention**
-
-   ```bash
-   # Conventional commits for auto-generation
-   feat: add user authentication
-   fix: resolve memory leak in tasks
-   docs: update API documentation
-   style: format code with prettier
-   refactor: reorganize user service
-   test: add unit tests for auth
-   chore: update dependencies
-   ```
-
-6. **Integration with Releases**
-   - Update changelog before each release
-   - Include in release notes
-   - Link to GitHub releases
-   - Tag versions consistently
-
-Remember to keep entries clear, categorized, and focused on user-facing changes.
+- One line per entry, describing a user-facing change.
+- Lead with a verb: "Add session refresh endpoint", not "Added a new endpoint
+  that lets users refresh sessions".
+- No commit hashes, file paths, or internal refactors that users cannot observe.

--- a/plugins/git-workflow/skills/commit/SKILL.md
+++ b/plugins/git-workflow/skills/commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: commit
-description: Writes brief conventional-commit messages and commits the staged changes. Use when the user asks to commit, stage and commit, or write a commit message.
+description: Writes brief conventional-commit messages, runs pre-commit checks, stages changes, commits them, and proposes splitting when the diff mixes concerns. Use when the user asks to commit, stage and commit, write a commit message, or split a change into atomic commits.
 user-invocable: true
 argument-hint: "[--no-verify] [--help]"
 allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*), Bash(git diff:*), Bash(git log:*)

--- a/plugins/git-workflow/skills/commit/SKILL.md
+++ b/plugins/git-workflow/skills/commit/SKILL.md
@@ -1,9 +1,12 @@
 ---
+name: commit
+description: Writes brief conventional-commit messages and commits the staged changes. Use when the user asks to commit, stage and commit, or write a commit message.
+user-invocable: true
+argument-hint: "[--no-verify] [--help]"
 allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*), Bash(git diff:*), Bash(git log:*)
-description: Creates brief conventional-commit messages
 ---
 
-# Claude Command: Commit
+# Commit - Conventional Commit Messages
 
 Creates commits with short conventional commit messages. Runs pre-commit checks
 and suggests splitting when the staged changes cover more than one concern.
@@ -11,7 +14,7 @@ and suggests splitting when the staged changes cover more than one concern.
 ## Usage
 
 ```bash
-/commit [--no-verify] [--help]
+/git-workflow:commit [--no-verify] [--help]
 ```
 
 ## Workflow

--- a/plugins/git-workflow/skills/pr/SKILL.md
+++ b/plugins/git-workflow/skills/pr/SKILL.md
@@ -1,9 +1,12 @@
 ---
-allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*), Bash(gh *)
-description: Creates a PR on GitHub
+name: pr
+description: Creates a draft GitHub pull request with a plain-text conventional-commit title and a succinct description of the branch. Use when the user asks to open, raise, or create a pull request or PR.
+user-invocable: true
+argument-hint: "[--base <branch>]"
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*), Bash(git log:*), Bash(git diff:*), Bash(git push:*), Bash(gh *), Read, Write
 ---
 
-# GitHub PR Creation Assistant
+# PR - GitHub Pull Request Creation
 
 Creates a draft pull request with a conventional-commit title and a short
 description of what the branch actually changes.


### PR DESCRIPTION
# Summary

Brings the `git-workflow` plugin up to date: its three commands become skills
(`skills/<name>/SKILL.md`), and the commit and PR messages they produce are now
plain-text and length-capped instead of emoji-prefixed and verbose.

## Changes

- Move `commands/{commit,pr,changelog}.md` to `skills/{commit,pr,changelog}/SKILL.md`
  and switch `plugin.json` from `commands` to `skills` (version 1.0.0 to 2.0.0)
- Add skill frontmatter (`name`, `description`, `user-invocable`,
  `argument-hint`, `allowed-tools`) matching the `dev-skills` convention
- Widen the `pr` skill's `allowed-tools`, which omitted the `git log`, `git
  diff`, `git push`, and file writes its own workflow performs
- `commit`: drop the emoji table, default to a subject-only message, and cap the
  body at what the diff cannot show
- `pr`: budget each body section, ban invented sections, and use this repo's
  real template instead of the `pr_agent:*` placeholders
- Update invocation names in both READMEs, `docs/MARKETPLACE.md`, and `CLAUDE.md`

## Testing

`make test` passes 6/6 and `markdownlint` is clean on every changed file.
`CLAUDE.md` has pre-existing MD022/MD032/MD060 errors on lines this branch does
not touch.

## Checklist

- [x] Code follows project conventions
- [x] Tests pass locally
- [x] Documentation updated if needed
- [x] Ready for review

## Notes

Breaking for anyone invoking the bare `/commit`, `/pr`, or `/changelog` names.

`git-workflow` is missing from `.claude-plugin/marketplace.json`, so
`claude code plugins install git-workflow` cannot resolve even though both
READMEs document it. Pre-existing and left alone here.
