### PR TITLE
fix(marketplace): register the four unlisted plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,6 +32,38 @@
       "version": "1.0.0",
       "keywords": ["skills", "go", "documentation", "architecture", "mentorship"],
       "category": "skills"
+    },
+    {
+      "name": "git-workflow",
+      "source": "./plugins/git-workflow",
+      "description": "Git workflow automation skills for commits, PRs, and changelog management",
+      "version": "2.0.0",
+      "keywords": ["git", "github", "workflow", "changelog"],
+      "category": "productivity"
+    },
+    {
+      "name": "pm-tools",
+      "source": "./plugins/pm-tools",
+      "description": "Project management commands for PRDs, task generation, and task tracking",
+      "version": "1.0.0",
+      "keywords": ["project-management", "prd", "tasks", "planning"],
+      "category": "productivity"
+    },
+    {
+      "name": "code-quality",
+      "source": "./plugins/code-quality",
+      "description": "Code quality analysis, review, and cleanup commands",
+      "version": "1.0.0",
+      "keywords": ["code-quality", "review", "linting", "cleanup"],
+      "category": "development"
+    },
+    {
+      "name": "prompt-tools",
+      "source": "./plugins/prompt-tools",
+      "description": "AI prompt generation and review tools for LLM development",
+      "version": "1.0.0",
+      "keywords": ["prompts", "ai", "llm", "prompt-engineering"],
+      "category": "ai"
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This is a Claude Code Template project that provides security hooks and testing 
 
 ## Marketplace Structure
 
-The repository is organized as a **marketplace with 6 installable plugins**:
+The repository is organized as a **marketplace with 7 installable plugins**:
 
 - **security-hooks**: MCP security scanner and protected branch hooks
 - **dev-skills**: Expert skills for Go, documentation, and architecture
@@ -18,6 +18,7 @@ The repository is organized as a **marketplace with 6 installable plugins**:
 - **pm-tools**: Project management commands for PRDs and tasks
 - **code-quality**: Code quality analysis, review, and cleanup
 - **prompt-tools**: AI prompt generation and review tools
+- **pr-review-triage**: Triage of PR review comments and follow-up tracking
 
 ### Directory Structure
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ PROTECT_BRANCH_SCRIPT := $(HOOKS_DIR)/protect-main-branch.sh
 MANIFEST_FILE := $(PLUGIN_DIR)/.claude-plugin/plugin.json
 TEST_SCRIPT := $(TESTS_DIR)/test-scanner.sh
 TEST_PROTECT_BRANCH_SCRIPT := $(TESTS_DIR)/test-protect-main-branch.sh
+TEST_MARKETPLACE_SCRIPT := $(TESTS_DIR)/test-marketplace.sh
 VALIDATE_SCRIPT := $(SCRIPTS_DIR)/validate-config.sh
 
 # Colors for output
@@ -41,6 +42,9 @@ test: ## Run complete test suite
 	@echo
 	@echo -e "$(BLUE)🧪 Running protected branch hook tests...$(NC)"
 	@$(TEST_PROTECT_BRANCH_SCRIPT)
+	@echo
+	@echo -e "$(BLUE)🧪 Running marketplace consistency tests...$(NC)"
+	@$(TEST_MARKETPLACE_SCRIPT)
 
 .PHONY: validate
 validate: ## Validate plugin manifest, hook scripts, and dependencies

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Production-ready Claude Code project template with security hooks, workflow auto
 - **Slash Commands**: Workflow automation for code quality, documentation, and project management
 - **Specialized Agents**: Expert agents for Go development, code review, and documentation
 - **Testing Infrastructure**: Comprehensive test suite with ~2000 lines of test coverage
-- **Marketplace Plugins**: Modular plugin architecture with 6 installable plugins
+- **Marketplace Plugins**: Modular plugin architecture with 7 installable plugins
 
 ## Installation
 
@@ -24,6 +24,7 @@ claude code plugins install git-workflow
 claude code plugins install pm-tools
 claude code plugins install code-quality
 claude code plugins install prompt-tools
+claude code plugins install pr-review-triage
 
 # Or install from GitHub
 claude code plugins install github:rikdc/claude_code_template/security-hooks
@@ -50,6 +51,7 @@ make test
 | [pm-tools](plugins/pm-tools/) | Productivity | Project management commands for PRDs and tasks |
 | [code-quality](plugins/code-quality/) | Development | Code quality analysis, review, and cleanup |
 | [prompt-tools](plugins/prompt-tools/) | AI | AI prompt generation and review tools |
+| [pr-review-triage](plugins/pr-review-triage/) | Workflow | Triage of PR review comments and follow-up tracking |
 
 ## Security Hooks
 
@@ -112,7 +114,8 @@ plugins/                          # Marketplace plugin distribution
 ├── git-workflow/                # Git automation skills
 ├── pm-tools/                    # Project management commands
 ├── code-quality/                # Code review and cleanup
-└── prompt-tools/                # AI prompt generation
+├── prompt-tools/                # AI prompt generation
+└── pr-review-triage/            # PR review comment triage
 
 .claude/                         # Local development structure
 ├── skills/                      # Specialized skills

--- a/docs/MARKETPLACE.md
+++ b/docs/MARKETPLACE.md
@@ -4,7 +4,7 @@ This document explains the marketplace structure and plugin distribution system 
 
 ## Overview
 
-The repository is organized as a **Claude Code marketplace** with 6 independent, installable plugins. This allows users to install only the components they need rather than getting everything at once.
+The repository is organized as a **Claude Code marketplace** with 7 independent, installable plugins. This allows users to install only the components they need rather than getting everything at once.
 
 ## Architecture
 
@@ -189,6 +189,31 @@ claude code plugins install prompt-tools
 ```
 
 **Documentation**: [plugins/prompt-tools/README.md](../plugins/prompt-tools/README.md)
+
+---
+
+### 7. pr-review-triage
+
+**Category**: Workflow
+**Source**: `./plugins/pr-review-triage`
+
+**Components**:
+
+- `/triage-reviews` - PR review comment triage skill
+- `/triage` - Legacy triage command
+
+**Features**:
+
+- Classifies review comments and accepts or rejects each with a reason
+- Creates tracked follow-up tasks for deferred feedback
+- Resolves handled threads on the pull request
+- Supports `--dry-run` and per-category auto-approval
+
+**Installation**:
+
+```bash
+claude code plugins install pr-review-triage
+```
 
 ---
 

--- a/tests/test-marketplace.sh
+++ b/tests/test-marketplace.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+
+# Marketplace Consistency Tests
+#
+# Each plugin's own .claude-plugin/plugin.json is the source of truth.
+# marketplace.json and the docs are derivative, so every check below reports
+# drift against the plugin manifest rather than the other way round.
+
+# Deliberately no -e: report every failure in one run, not just the first.
+set -uo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$PROJECT_ROOT" || exit 1
+
+readonly MARKETPLACE=".claude-plugin/marketplace.json"
+readonly README="README.md"
+readonly MARKETPLACE_DOC="docs/MARKETPLACE.md"
+
+PASSED=0
+FAILED=0
+
+pass() {
+    echo "  ✓ $1"
+    PASSED=$((PASSED + 1))
+}
+
+fail() {
+    echo "  ✗ $1"
+    FAILED=$((FAILED + 1))
+}
+
+echo "🧪 Marketplace Consistency Tests"
+echo "================================"
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "❌ jq is required but not installed"
+    exit 1
+fi
+
+if ! jq -e . "$MARKETPLACE" >/dev/null 2>&1; then
+    echo "❌ $MARKETPLACE is missing or not valid JSON"
+    exit 1
+fi
+
+registered=$(jq -r '.plugins[].name' "$MARKETPLACE" | sort)
+
+echo
+echo "🚀 Registry covers the filesystem..."
+
+on_disk=$(find plugins -mindepth 1 -maxdepth 1 -type d | sed 's|plugins/||' | sort)
+
+unregistered=$(comm -23 <(echo "$on_disk") <(echo "$registered"))
+if [[ -z "$unregistered" ]]; then
+    pass "every plugin directory is registered"
+else
+    fail "unregistered plugin(s): $(echo "$unregistered" | tr '\n' ' ')"
+fi
+
+orphaned=$(comm -13 <(echo "$on_disk") <(echo "$registered"))
+if [[ -z "$orphaned" ]]; then
+    pass "every registered plugin exists on disk"
+else
+    fail "registered but missing from disk: $(echo "$orphaned" | tr '\n' ' ')"
+fi
+
+echo
+echo "🚀 Registry entries match their plugin manifests..."
+
+while IFS= read -r name; do
+    [[ -z "$name" ]] && continue
+
+    source_path=$(jq -r --arg n "$name" '.plugins[]|select(.name==$n)|.source' "$MARKETPLACE")
+    manifest="$source_path/.claude-plugin/plugin.json"
+
+    if [[ ! -f "$manifest" ]]; then
+        fail "$name: source '$source_path' has no plugin.json"
+        continue
+    fi
+
+    for field in version description; do
+        registry_value=$(jq -r --arg n "$name" --arg f "$field" \
+            '.plugins[]|select(.name==$n)|.[$f]' "$MARKETPLACE")
+        manifest_value=$(jq -r --arg f "$field" '.[$f]' "$manifest")
+
+        if [[ "$registry_value" == "$manifest_value" ]]; then
+            pass "$name: $field matches manifest"
+        else
+            fail "$name: $field is '$registry_value' but manifest says '$manifest_value'"
+        fi
+    done
+
+    # A manifest that points at a directory removed by a refactor still parses
+    # cleanly, so check the declared component paths resolve to real content.
+    for component in commands skills; do
+        while IFS= read -r declared; do
+            [[ -z "$declared" ]] && continue
+            resolved="$source_path/${declared#./}"
+            if [[ -d "$resolved" ]] && [[ -n "$(ls -A "$resolved")" ]]; then
+                pass "$name: $component path '$declared' exists"
+            else
+                fail "$name: $component path '$declared' is missing or empty"
+            fi
+        done < <(jq -r --arg c "$component" '.[$c][]? // empty' "$manifest")
+    done
+
+    # hooks is an event-to-matcher object, not a path list: check that each
+    # configured command resolves to an executable script in the plugin.
+    while IFS= read -r hook_command; do
+        [[ -z "$hook_command" ]] && continue
+        script=$(echo "$hook_command" | tr -d '"' | sed "s|\${CLAUDE_PLUGIN_ROOT}|$source_path|")
+        script="${script%% *}"
+        if [[ -x "$script" ]]; then
+            pass "$name: hook script '$(basename "$script")' is executable"
+        else
+            fail "$name: hook script '$script' is missing or not executable"
+        fi
+    done < <(jq -r '.hooks? // {} | .[]? | .[]? | .hooks[]? | .command' "$manifest")
+done <<<"$registered"
+
+echo
+echo "🚀 Skills are well-formed..."
+
+while IFS= read -r skill; do
+    [[ -z "$skill" ]] && continue
+
+    dir_name=$(basename "$(dirname "$skill")")
+    frontmatter=$(awk '/^---$/{c++; next} c==1' "$skill")
+    skill_name=$(echo "$frontmatter" | grep '^name:' | head -1 | sed 's/^name:[[:space:]]*//')
+    skill_desc=$(echo "$frontmatter" | grep '^description:' | head -1 | sed 's/^description:[[:space:]]*//')
+
+    if [[ "$skill_name" == "$dir_name" ]]; then
+        pass "$dir_name: frontmatter name matches directory"
+    else
+        fail "$dir_name: frontmatter name is '$skill_name'"
+    fi
+
+    if [[ -n "$skill_desc" ]]; then
+        pass "$dir_name: has a description"
+    else
+        fail "$dir_name: description is missing or empty"
+    fi
+done < <(find plugins -path '*/skills/*/SKILL.md' -type f | sort)
+
+echo
+echo "🚀 Docs list every registered plugin..."
+
+while IFS= read -r name; do
+    [[ -z "$name" ]] && continue
+
+    if grep -q "plugins/$name" "$README"; then
+        pass "$name: appears in $README"
+    else
+        fail "$name: missing from $README"
+    fi
+
+    if grep -qE "^### [0-9]+\. $name\$" "$MARKETPLACE_DOC"; then
+        pass "$name: has a section in $MARKETPLACE_DOC"
+    else
+        fail "$name: missing from $MARKETPLACE_DOC"
+    fi
+done <<<"$registered"
+
+echo
+total=$((PASSED + FAILED))
+echo "📊 Tests: $total, Passed: $PASSED, Failed: $FAILED"
+
+if [[ "$FAILED" -eq 0 ]]; then
+    echo "✅ All tests passed!"
+    exit 0
+else
+    echo "❌ $FAILED test(s) failed!"
+    exit 1
+fi


### PR DESCRIPTION
# Summary

`marketplace.json` registered only three of the seven plugins in `plugins/`, so
`git-workflow`, `pm-tools`, `code-quality`, and `prompt-tools` could not be
installed despite the READMEs documenting install commands for them. Adds a
test suite so the registry, the plugin manifests, and the docs cannot drift
apart again.

## Changes

- Register the four missing plugins, copying name, version, description, and
  keywords from each plugin's own `plugin.json`
- Correct the plugin count from 6 to 7 in `README.md`, `CLAUDE.md`, and
  `docs/MARKETPLACE.md`, and document `pr-review-triage`, which was registered
  but absent from every list
- Add `tests/test-marketplace.sh` and wire it into `make test`: registry covers
  the filesystem both ways, versions and descriptions match each manifest,
  declared `commands`/`skills` paths resolve to real content, hook commands
  point at executable scripts, `SKILL.md` frontmatter names match their
  directories, and every registered plugin appears in both docs

## Testing

`make test` passes, 63 new checks among them. Verified the suite actually
fails by injecting three faults in turn — a wrong version in the registry, a
dropped plugin entry, and a skill whose frontmatter name did not match its
directory — each caught with the expected message, then reverted.

## Checklist

- [x] Code follows project conventions
- [x] Tests pass locally
- [x] Documentation updated if needed
- [x] Ready for review

## Notes

`plugins/pr-review-triage/README.md` does not exist, so its new section omits
the **Documentation** link that the other six carry.
