### PR TITLE
feat(git-workflow): detect forge and use gh or tea for PRs

### DIFF
--- a/plugins/git-workflow/skills/pr/SKILL.md
+++ b/plugins/git-workflow/skills/pr/SKILL.md
@@ -1,24 +1,57 @@
 ---
 name: pr
-description: Creates a draft GitHub pull request with a plain-text conventional-commit title and a succinct description of the branch. Use when the user asks to open, raise, or create a pull request or PR.
+description: Creates a draft pull request with a plain-text conventional-commit title and a succinct description of the branch. Detects whether the repo lives on GitHub or a Forgejo/Gitea host and uses gh or tea accordingly. Use when the user asks to open, raise, or create a pull request or PR.
 user-invocable: true
 argument-hint: "[--base <branch>]"
-allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*), Bash(git log:*), Bash(git diff:*), Bash(git push:*), Bash(gh *), Read, Write
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*), Bash(git log:*), Bash(git diff:*), Bash(git push:*), Bash(git remote:*), Bash(git config:*), Bash(git branch:*), Bash(gh *), Bash(tea *), Bash(curl:*), Read, Write
 ---
 
-# PR - GitHub Pull Request Creation
+# PR - Pull Request Creation
 
 Creates a draft pull request with a conventional-commit title and a short
-description of what the branch actually changes.
+description of what the branch actually changes. Works against GitHub (`gh`)
+and Forgejo/Gitea (`tea`).
 
 ## Workflow
 
-1. **Validate**: `gh auth status`, current branch, uncommitted changes.
-2. **Read the branch**: `git log <base>..HEAD` and `git diff <base>...HEAD` —
+1. **Detect the forge**: run the detection below. Never assume GitHub.
+2. **Validate**: auth for that forge, current branch, uncommitted changes.
+3. **Read the branch**: `git log <base>..HEAD` and `git diff <base>...HEAD` —
    the description covers exactly this, nothing more.
-3. **Write the body**: use `.github/pull_request_template.md` if present,
-   otherwise the sections below.
-4. **Create**: `gh pr create --draft --title "<type>(<scope>): <subject>" --body-file <file> --base main`
+4. **Write the body**: use the PR template if present, otherwise the sections
+   below.
+5. **Push**: `git push -u <remote> HEAD`. Neither CLI reliably pushes for you.
+6. **Create**: the command for the detected forge (see Commands by Forge).
+
+## Forge Detection
+
+Resolve the host from the remote the branch actually pushes to, then classify
+it:
+
+```bash
+branch=$(git branch --show-current)
+remote=$(git config --get "branch.$branch.remote" || echo origin)
+url=$(git remote get-url "$remote")
+host=$(printf '%s' "$url" | sed -E 's#^[a-z+]+://##; s#^[^@]+@##; s#[:/].*$##')
+echo "$remote $host"
+```
+
+Classify in this order — the first match wins:
+
+1. `host` is `github.com` → **GitHub**.
+2. `gh auth status` lists `host` → **GitHub** (Enterprise).
+3. `curl -sf -m 5 "https://$host/api/v1/version"` returns `{"version":"..."}`
+   → **Forgejo/Gitea**. This endpoint is the reliable tell; GitHub does not
+   serve it.
+4. Anything else (GitLab, Bitbucket, unreachable host) → **stop and ask**. Do
+   not guess a CLI, and do not fall back to `gh` because it happens to be
+   installed.
+
+Check the `gh` hosts before probing the API — GitHub Enterprise has no
+`/api/v1/version`, so probing first would misclassify it as unknown.
+
+State the detected forge and host in one line before creating anything, in the
+form `<forge> (<host>) — using <cli>`.
 
 ## Title Rules
 
@@ -37,6 +70,10 @@ Examples:
 
 Keep it succinct. The PR body describes the commits on the branch and nothing
 else.
+
+Look for a template at `.forgejo/pull_request_template.md`,
+`.gitea/pull_request_template.md`, then `.github/pull_request_template.md`,
+and use the first that exists — Forgejo reads all three, GitHub only the last.
 
 - **Summary**: one to three sentences. What changed and why. No restating the
   title, no background essay.
@@ -85,17 +122,40 @@ passed the scan. Matching is now case-insensitive.
 `make test` — all suites pass.
 ```
 
-## Common Actions
+## Commands by Forge
 
-```bash
-gh pr ready <PR-NUMBER>                                    # draft to ready
-gh pr edit <PR-NUMBER> --add-reviewer user1,user2          # add reviewers
-gh pr status                                               # check status
-```
+The title and body rules above are identical for both. Only the CLI changes.
+
+| Action | GitHub | Forgejo/Gitea |
+| --- | --- | --- |
+| Check auth | `gh auth status` | `tea login list` |
+| Create draft | `gh pr create --draft --base <base> --title "<title>" --body-file <file>` | `tea pr create --draft --base <base> --title "<title>" --description "$(cat <file>)"` |
+| Draft to ready | `gh pr ready <N>` | `tea pulls edit <N> --ready` |
+| Add reviewers | `gh pr edit <N> --add-reviewer u1,u2` | `tea pulls edit <N> --add-reviewers u1,u2` |
+| Status / list | `gh pr status` | `tea pulls list` |
+
+`tea` specifics worth knowing:
+
+- No `--body-file`. Write the body to a file as usual, then pass it inline with
+  `--description "$(cat <file>)"` so the heredoc-style body survives intact.
+- `--draft` prepends `WIP: ` to the title; Gitea and Forgejo treat a
+  WIP-prefixed PR as a draft. `tea pulls edit --ready` strips it again. The
+  prefix is part of the title, so keep the underlying title within the 70-char
+  rule with room for it.
+- Use long flags only. On `tea pulls edit`, `-r` is claimed by both `--repo`
+  and `--add-reviewers`.
+- If a repo has several logins configured, disambiguate with
+  `--remote <remote>` rather than `--login`, so the PR follows the branch's
+  actual push target.
 
 ## Error Handling
 
-- Missing `gh`: prompt to install.
-- Not authenticated: run `gh auth status` and prompt to log in.
+- Forge not identified: stop and ask which forge and CLI to use. Do not default
+  to `gh`.
+- Missing CLI: prompt to install (`gh`, or `tea` for Forgejo/Gitea).
+- Not authenticated: GitHub — `gh auth status`, prompt to log in. Forgejo —
+  `tea login list`; if the host is absent, prompt for
+  `tea login add --name <name> --url https://<host> --token <token>` rather
+  than attempting an interactive login.
 - Missing PR template: use the default body above; do not create the template
   file unless asked.


### PR DESCRIPTION
# Summary

The `pr` skill assumed every repository lives on GitHub, so it always reached
for `gh`. It now identifies the forge first and uses the matching CLI, adding
support for Forgejo and Gitea via `tea`.

## Changes

- Resolve the host from the remote the current branch pushes to, rather than
  assuming `origin`
- Classify the host as GitHub, GitHub Enterprise, or Forgejo/Gitea, checking
  `gh`'s known hosts before probing `/api/v1/version` so Enterprise is not
  misread as unknown
- Stop and ask on an unrecognised host instead of falling back to `gh`
- Add `tea` equivalents for create, draft-to-ready, reviewers and status, plus
  the flag differences that bite (no `--body-file`, `--draft` prepends `WIP: `,
  ambiguous `-r` on `tea pulls edit`)
- Search `.forgejo/`, `.gitea/` and `.github/` for a PR template
- Add an explicit push step; neither CLI reliably pushes for you

Title and body rules are unchanged and apply identically to both forges.

## Testing

`make lint` passes (ShellCheck, markdownlint). Detection was checked against
three real repositories and classified each correctly: a Forgejo host, and two
on github.com. The `tea` commands and flags were verified against tea 0.14.2,
but no pull request has been created through the `tea` path yet, so that branch
of the workflow is unexercised.

## Checklist

- [x] Code follows project conventions
- [x] Tests pass locally
- [x] Documentation updated if needed
- [x] Ready for review
