### PR TITLE
chore: rename project from claude-code-template to ai-skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "claude-code-template",
+  "name": "ai-skills",
   "owner": {
     "name": "Richard Claydon"
   },

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Claude Code Template - Git Ignore Rules
+# AI Skills - Git Ignore Rules
 
 # Security scan logs (sensitive data may be logged)
 *.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a Claude Code Template project that provides security hooks and testing infrastructure for Claude Code projects. The main features are:
+This is the AI Skills project, which provides security hooks and testing infrastructure for Claude Code projects. The main features are:
 1. Security scanning to prevent sensitive data from being sent to external MCP services
 2. Branch protection to enforce PR-based workflows by preventing direct edits to protected branches (main, master, production, release)
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Makefile for Claude Code Template
+# Makefile for AI Skills
 # Provides a simple interface for common operations
 
 # Configuration
@@ -128,7 +128,7 @@ check-tools: ## Check for required and optional tools
 
 .PHONY: status
 status: ## Show current status and configuration
-	@echo -e "$(BLUE)📊 Claude Code Template Status$(NC)"
+	@echo -e "$(BLUE)📊 AI Skills Status$(NC)"
 	@echo
 	@echo "Configuration:"
 	@echo "  Project root: $(PROJECT_ROOT)"
@@ -143,7 +143,7 @@ status: ## Show current status and configuration
 
 .PHONY: help
 help: ## Display this help
-	@echo -e "$(BLUE)Claude Code Template - Make Targets$(NC)"
+	@echo -e "$(BLUE)AI Skills - Make Targets$(NC)"
 	@echo
 	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) }' $(MAKEFILE_LIST)
 	@echo

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Claude Code Template
+# AI Skills
 
 A Claude Code marketplace of seven plugins. Two are security hooks: one scans
 MCP traffic for secrets, the other stops you editing protected branches
@@ -14,13 +14,13 @@ Add the marketplace, then install plugins from it:
 ```bash
 claude plugin marketplace add rikdc/ai-skills
 
-claude plugin install security-hooks@claude-code-template
-claude plugin install dev-skills@claude-code-template
-claude plugin install git-workflow@claude-code-template
-claude plugin install pm-tools@claude-code-template
-claude plugin install code-quality@claude-code-template
-claude plugin install prompt-tools@claude-code-template
-claude plugin install pr-review-triage@claude-code-template
+claude plugin install security-hooks@ai-skills
+claude plugin install dev-skills@ai-skills
+claude plugin install git-workflow@ai-skills
+claude plugin install pm-tools@ai-skills
+claude plugin install code-quality@ai-skills
+claude plugin install prompt-tools@ai-skills
+claude plugin install pr-review-triage@ai-skills
 ```
 
 The `/plugin` command does the same thing from inside a session.

--- a/docs/MARKETPLACE.md
+++ b/docs/MARKETPLACE.md
@@ -1,6 +1,6 @@
-# Claude Code Template Marketplace
+# AI Skills Marketplace
 
-This document explains the marketplace structure and plugin distribution system for the Claude Code Template repository.
+This document explains the marketplace structure and plugin distribution system for the AI Skills repository.
 
 ## Overview
 
@@ -263,7 +263,7 @@ The top-level `.claude-plugin/marketplace.json` registers all plugins:
 
 ```json
 {
-  "name": "claude-code-template",
+  "name": "ai-skills",
   "owner": {
     "name": "Richard Claydon"
   },
@@ -305,8 +305,8 @@ claude code plugins install dev-skills
 #### Option 2: Clone entire repository
 
 ```bash
-git clone https://github.com/rikdc/claude_code_template.git
-cd claude_code_template
+git clone https://github.com/rikdc/ai-skills.git
+cd ai-skills
 make install
 ```
 
@@ -321,7 +321,7 @@ claude code plugins install <plugin-name>
 ### From GitHub Repository
 
 ```bash
-claude code plugins install github:rikdc/claude_code_template/<plugin-name>
+claude code plugins install github:rikdc/ai-skills/<plugin-name>
 ```
 
 ### From Local Directory

--- a/plugins/code-quality/README.md
+++ b/plugins/code-quality/README.md
@@ -50,7 +50,7 @@ claude code plugins install code-quality
 Or install from this repository:
 
 ```bash
-claude code plugins install github:rikdc/claude_code_template/code-quality
+claude code plugins install github:rikdc/ai-skills/code-quality
 ```
 
 ## Usage Examples

--- a/plugins/dev-skills/README.md
+++ b/plugins/dev-skills/README.md
@@ -63,7 +63,7 @@ claude code plugins install dev-skills
 Or install from this repository:
 
 ```bash
-claude code plugins install github:rikdc/claude_code_template/dev-skills
+claude code plugins install github:rikdc/ai-skills/dev-skills
 ```
 
 ## Usage Examples

--- a/plugins/git-workflow/README.md
+++ b/plugins/git-workflow/README.md
@@ -48,7 +48,7 @@ claude code plugins install git-workflow
 Or install from this repository:
 
 ```bash
-claude code plugins install github:rikdc/claude_code_template/git-workflow
+claude code plugins install github:rikdc/ai-skills/git-workflow
 ```
 
 ## Usage Examples

--- a/plugins/pm-tools/README.md
+++ b/plugins/pm-tools/README.md
@@ -48,7 +48,7 @@ claude code plugins install pm-tools
 Or install from this repository:
 
 ```bash
-claude code plugins install github:rikdc/claude_code_template/pm-tools
+claude code plugins install github:rikdc/ai-skills/pm-tools
 ```
 
 ## Usage Examples

--- a/plugins/pr-review-triage/README.md
+++ b/plugins/pr-review-triage/README.md
@@ -1,0 +1,70 @@
+# PR Review Triage Plugin
+
+Triage PR review comments — classify, accept/reject, and track follow-up work.
+
+## What's Included
+
+### `/triage-reviews` (skill)
+
+Systematically processes unresolved review comments on a pull request: classifies each one, evaluates it against the actual code and project conventions, presents a summary, and acts only after you confirm.
+
+**Features**:
+
+- Classifies comments into weighted categories (security, correctness, error-handling, performance, design, testing, style, nit, praise, question)
+- Reads the referenced file and line before judging a comment, rather than evaluating it in isolation
+- Cites project conventions when rejecting a suggestion
+- Resolves comment threads and creates tracked follow-up tasks for accepted work
+- Filters out self-review comments and replies to existing threads
+
+### `/triage` (command)
+
+Slash-command entry point to the same triage workflow.
+
+## Installation
+
+Install via Claude Code marketplace:
+
+```bash
+claude code plugins install pr-review-triage
+```
+
+Or install from this repository:
+
+```bash
+claude code plugins install github:rikdc/ai-skills/pr-review-triage
+```
+
+## Requirements
+
+The [`gh` CLI](https://cli.github.com/) must be installed and authenticated — the plugin reads PR comments and diffs through `gh pr` and `gh api`.
+
+## Usage Examples
+
+```bash
+# Triage reviews on the current branch's PR
+/triage-reviews
+
+# Triage a specific PR
+/triage-reviews 123
+
+# Preview decisions without acting
+/triage-reviews --dry-run
+
+# Auto-accept an entire category
+/triage-reviews --auto-approve security
+
+# Leave comment threads unresolved
+/triage-reviews --no-resolve
+```
+
+## Best Practices
+
+- Start with `--dry-run` on an unfamiliar PR to see the proposed classifications before anything is acted on.
+- Reserve `--auto-approve` for categories where the decision is never in doubt, such as `security`.
+- Make sure the repository's CLAUDE.md and linter config are current — rejections are argued from those conventions.
+
+## License
+
+Mozilla Public License 2.0 — see [LICENSE](../../LICENSE).
+</content>
+</invoke>

--- a/plugins/prompt-tools/README.md
+++ b/plugins/prompt-tools/README.md
@@ -39,7 +39,7 @@ claude code plugins install prompt-tools
 Or install from this repository:
 
 ```bash
-claude code plugins install github:rikdc/claude_code_template/prompt-tools
+claude code plugins install github:rikdc/ai-skills/prompt-tools
 ```
 
 ## Usage Examples

--- a/plugins/security-hooks/README.md
+++ b/plugins/security-hooks/README.md
@@ -29,7 +29,7 @@ claude code plugins install security-hooks
 Or install from this repository:
 
 ```bash
-claude code plugins install github:rikdc/claude_code_template/security-hooks
+claude code plugins install github:rikdc/ai-skills/security-hooks
 ```
 
 ## Configuration


### PR DESCRIPTION
The repository was renamed to `ai-skills`, but the old name was still
present throughout the docs and the marketplace manifest.

## Changes

- **Marketplace name** — `.claude-plugin/marketplace.json` now registers as
  `ai-skills`. This also covers the `plugin install <name>@claude-code-template`
  suffixes in the README and the copy of the manifest embedded in
  `docs/MARKETPLACE.md`.
- **Install and clone commands** — the `github:rikdc/claude_code_template/...`
  install paths and the clone URL / `cd` pair were broken. Fixed in the
  marketplace docs and the six plugin READMEs carrying them.
- **Titles and prose** — README, marketplace docs, Makefile banners,
  `.gitignore` header, and the CLAUDE.md overview sentence.
- **New README** for `pr-review-triage`, the only plugin without one.

## Breaking

Renaming the marketplace means anyone who already added it under the old
name must re-add it to pick up updates.

## Verification

- `make test` — passes; scanner suite 6/6, branch-protection suite clean
- `jq -e .name .claude-plugin/marketplace.json` — valid JSON, returns `ai-skills`
- No remaining matches for `claude_code_template` / `claude-code-template` /
  `Claude Code Template` in tracked files