### PR TITLE
ci: add claudelint workflow for Claude configuration validation

### DIFF
--- a/.github/workflows/claudelint.yml
+++ b/.github/workflows/claudelint.yml
@@ -1,0 +1,31 @@
+---
+name: Claude Config Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  claudelint:
+    name: Lint Claude Configuration
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install claudelint
+        run: npm install -g claude-code-lint@0.7.1
+
+      - name: Lint Claude configuration
+        run: claudelint check-all --format github

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ tests/output/
 tests/**/test-results.log
 lint-report.txt
 
+# claudelint cache
+.claudelint-cache/
+
 # Temporary files
 *.tmp
 *.temp

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ TEST_PROTECT_BRANCH_SCRIPT := $(TESTS_DIR)/test-protect-main-branch.sh
 TEST_MARKETPLACE_SCRIPT := $(TESTS_DIR)/test-marketplace.sh
 VALIDATE_SCRIPT := $(SCRIPTS_DIR)/validate-config.sh
 
+# Pinned tool versions
+CLAUDELINT_VERSION := 0.7.1
+
 # Colors for output
 BLUE := \033[0;34m
 GREEN := \033[0;32m
@@ -70,6 +73,18 @@ lint: ## Run ShellCheck on shell scripts and markdownlint on Markdown files
 		echo -e "  $(GREEN)✅ markdownlint passed$(NC)"; \
 	else \
 		echo -e "  $(YELLOW)⚠️  markdownlint not installed - skipping Markdown linting$(NC)"; \
+	fi
+	@echo
+	@$(MAKE) --no-print-directory lint-claude
+
+.PHONY: lint-claude
+lint-claude: ## Run claudelint on Claude Code configuration
+	@echo "Claude configuration:"
+	@if command -v npx >/dev/null 2>&1; then \
+		npx --yes claude-code-lint@$(CLAUDELINT_VERSION) check-all && \
+		echo -e "  $(GREEN)✅ claudelint passed$(NC)"; \
+	else \
+		echo -e "  $(YELLOW)⚠️  npx not installed - skipping Claude configuration linting$(NC)"; \
 	fi
 
 ##@ Installation and Setup


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that runs [claudelint](https://claudelint.com) against this repository's Claude Code configuration on every push and pull request to `main`.

Since this repo *is* a collection of Claude Code plugins and hooks, a linter that validates `CLAUDE.md`, `settings.json`, and the plugin marketplace manifest catches a class of breakage the existing ShellCheck and markdownlint jobs cannot see.

## Changes

- **`.github/workflows/claudelint.yml`** — new workflow, mirroring the structure of the existing `linter.yml` and `test.yml`. Uses `--format github` so findings land as annotations on the PR diff.
- **`Makefile`** — new `make lint-claude` target, wired into `make lint`, so the same check runs locally. Skips gracefully if `npx` is unavailable, in keeping with how the ShellCheck and markdownlint steps behave.
- **`.gitignore`** — ignore `.claudelint-cache/`, which the tool writes on run.

## Notes on the approach

- **The version is pinned** rather than floating. A new claudelint release that adds rules or promotes a warning to an error would otherwise turn CI red on an unrelated PR; pinned means upgrades are a reviewable commit.
- **No SARIF / Code Scanning upload.** That path exists for repos exceeding the 50-annotation limit — we have 19. It would require granting `security-events: write` for no benefit at this size.
- **No `.claudelintrc.json`.** The defaults already produce zero errors, and adding config to suppress warnings we haven't triaged would hide signal.

## Current baseline

```
Checked 3 files across 3 categories (claude-md, settings, plugin)
19 problems (0 errors, 19 warnings)   → exit code 0
```

The check passes today. The 19 warnings are left for a follow-up, and split into two groups:

1. **`CLAUDE.md` (12 warnings)** — genuinely stale file references to `.claude/skills/`, `.claude/agents/`, and `.claude/commands/`, which moved under `plugins/` in an earlier refactor. Real, worth fixing.
2. **`.claude-plugin/marketplace.json` (7 warnings)** — **real, and install-breaking.**
   Initially triaged these as false positives; that was wrong. The
   [spec](https://code.claude.com/docs/en/plugin-marketplaces) states
   `metadata.pluginRoot` is *prepended* to relative plugin source paths. This
   marketplace sets `pluginRoot: "./plugins"` *and* `source: "./plugins/<name>"`,
   so every plugin resolves to `./plugins/plugins/<name>`. Verified against
   claudelint in isolation: removing `pluginRoot` clears all 7 warnings.
   Tracked and fixed separately as a bugfix.

Fixing these in the same PR would mix a CI change with content changes, so they're deliberately out of scope here.

## Verification

- `make lint` — ShellCheck, markdownlint, and claudelint all pass (exit 0)
- `make lint-claude` — passes standalone (exit 0)
- Workflow YAML parses and resolves to four named steps

