### PR TITLE
fix(marketplace): remove double-prefixed plugin source paths

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,8 +5,7 @@
   },
   "metadata": {
     "description": "Security hooks, branch protection, and development skills for Claude Code projects",
-    "version": "1.0.0",
-    "pluginRoot": "./plugins"
+    "version": "1.0.0"
   },
   "plugins": [
     {


### PR DESCRIPTION
## Summary

Every plugin in this marketplace resolves to a path that does not exist. `metadata.pluginRoot` was set to `./plugins` while each plugin entry's `source` was already `./plugins/<name>`, so the two combine into `./plugins/plugins/<name>`.

Per the [marketplace reference](https://code.claude.com/docs/en/plugin-marketplaces), `metadata.pluginRoot` is:

> Base directory prepended to relative plugin source paths (for example, `"./plugins"` lets you write `"source": "formatter"` instead of `"source": "./plugins/formatter"`)

The two fields are alternatives, not complements. All seven plugins were affected.

## Fix

Removes `metadata.pluginRoot` and keeps the explicit `./plugins/<name>` source paths.

The alternative — keeping `pluginRoot` and shortening each `source` to a bare name — resolves identically, but `tests/test-marketplace.sh` builds `"$source_path/.claude-plugin/plugin.json"` from the repository root. Keeping the explicit paths means that test continues to work unchanged.

## Verification

Isolated reproduction against claudelint v0.7.1, using a scratch marketplace with all seven plugin directories present:

| `pluginRoot` | `source` | Result |
| --- | --- | --- |
| `./plugins` | `./security-hooks` | clean |
| `./plugins` | `./plugins/security-hooks` | **7 warnings** (config before this change) |
| *(absent)* | `./plugins/security-hooks` | clean (this change) |

In this repository:

- `claudelint check-all` — marketplace warnings go from 7 to 0 (19 total to 12; the remainder are unrelated stale `CLAUDE.md` references, handled separately)
- `make test` — passes, exit 0, including the marketplace consistency suite
- `make validate` — passes, exit 0
- Diff is one line; the file is otherwise untouched and still valid JSON

## Notes

Found while adding claudelint to CI (#52). That PR's description originally dismissed these warnings as false positives — an incorrect call, since corrected there.
