### PR TITLE
ci: bump GitHub Actions to v7 and Node to 22

### DIFF
--- a/.github/workflows/claudelint.yml
+++ b/.github/workflows/claudelint.yml
@@ -17,12 +17,12 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install claudelint
         run: npm install -g claude-code-lint@0.7.1

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary

Every workflow run currently emits a deprecation annotation:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4

Runners are already overriding the requested runtime, so this is a warning rather than a failure — but it appears on all three workflows on every run, and the override won't last indefinitely.

## Changes

| Pin | Before | After |
| --- | --- | --- |
| `actions/checkout` (×3 workflows) | `v4` | `v7` |
| `actions/setup-node` | `v4` | `v7` |
| `node-version` (claudelint job) | `20` | `22` |

## Compatibility

Reviewed the v5→v7 release notes for both actions. Nothing affects the usage here:

- **checkout v7** — the notable change is blocking fork PR checkout under `pull_request_target` and `workflow_run`. Neither trigger is used in this repo; all three workflows are `push` / `pull_request` on `main`.
- **setup-node v7** — ESM migration, two new cache outputs, and a fix to `mirrorToken` handling. No input changes to what's used here.

`node-version` moves to 22 because Node 20 is now past active LTS. claudelint declares `engines.node >= 20.0.0`, so 22 is comfortably in range.

## Verification

- All three workflow files still parse as valid YAML
- Diff is 5 lines, pins only — no structural or logic changes
- The deprecation annotation was the only annotation on the last `main` run of the claudelint job, so this should take that job to zero annotations

## Not included

`super-linter` stays pinned at `v8.0.0` (latest is `v8.7.0`). It's a Docker action and unaffected by the Node deprecation, and super-linter minors adjust bundled linter versions and rules — which can surface new findings and turn the lint job red. That belongs in its own PR where the diff is about the findings, not mixed into a pin bump.
