### PR TITLE
feat: share plugin skills with Codex

### DIFF
--- a/.codex/skills/changelog
+++ b/.codex/skills/changelog
@@ -1,0 +1,1 @@
+../../plugins/git-workflow/skills/changelog

--- a/.codex/skills/commit
+++ b/.codex/skills/commit
@@ -1,0 +1,1 @@
+../../plugins/git-workflow/skills/commit

--- a/.codex/skills/document
+++ b/.codex/skills/document
@@ -1,0 +1,1 @@
+../../plugins/dev-skills/skills/document

--- a/.codex/skills/go-implementor
+++ b/.codex/skills/go-implementor
@@ -1,0 +1,1 @@
+../../plugins/dev-skills/skills/go-implementor

--- a/.codex/skills/go-review
+++ b/.codex/skills/go-review
@@ -1,0 +1,1 @@
+../../plugins/dev-skills/skills/go-review

--- a/.codex/skills/golang-expert
+++ b/.codex/skills/golang-expert
@@ -1,0 +1,1 @@
+../../plugins/dev-skills/skills/golang-expert

--- a/.codex/skills/manager
+++ b/.codex/skills/manager
@@ -1,0 +1,1 @@
+../../plugins/dev-skills/skills/manager

--- a/.codex/skills/mentor
+++ b/.codex/skills/mentor
@@ -1,0 +1,1 @@
+../../plugins/dev-skills/skills/mentor

--- a/.codex/skills/pr
+++ b/.codex/skills/pr
@@ -1,0 +1,1 @@
+../../plugins/git-workflow/skills/pr

--- a/.codex/skills/specify
+++ b/.codex/skills/specify
@@ -1,0 +1,1 @@
+../../plugins/dev-skills/skills/specify

--- a/.codex/skills/taskify
+++ b/.codex/skills/taskify
@@ -1,0 +1,1 @@
+../../plugins/dev-skills/skills/taskify

--- a/.codex/skills/triage-reviews
+++ b/.codex/skills/triage-reviews
@@ -1,0 +1,1 @@
+../../plugins/pr-review-triage/skills/triage-reviews

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# AGENTS.md
+
+## Repository purpose
+
+This repository is a Claude Code marketplace and a shared collection of
+development-agent workflows. The Claude-specific plugin manifests live under
+`plugins/*/.claude-plugin/`; Codex-specific integration lives under `.codex/`.
+Do not assume those packaging formats are interchangeable.
+
+## Codex skills
+
+The reusable plugin skills are exposed to Codex through symlinks in
+`.codex/skills/`. Their sources of truth are the `plugins/*/skills/`
+directories.
+
+- Use a matching skill when a task clearly fits its stated workflow.
+- Edit the source skill, not its `.codex/skills/` symlink.
+- Keep skills provider-neutral unless a platform-specific instruction is
+  essential.
+
+## Commands and verification
+
+Run relevant checks before handing off changes:
+
+```bash
+make test       # Hook tests
+make validate   # Plugin manifest, scripts, and dependencies
+make lint       # ShellCheck/Markdown lint when installed
+```
+
+`jq`, `grep`, `awk`, and `mktemp` are required for the security-hook tooling.
+
+## Boundaries
+
+- Keep Claude plugin manifests and hooks unchanged unless the task explicitly
+  targets Claude Code.
+- The shell scripts in `plugins/security-hooks/` are portable utilities, but
+  their Claude hook registration is not a Codex configuration.
+- Add Codex-specific hooks, MCP settings, or a `.codex-plugin` manifest only
+  when that integration is explicitly being implemented.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,15 +17,19 @@ directories.
 - Edit the source skill, not its `.codex/skills/` symlink.
 - Keep skills provider-neutral unless a platform-specific instruction is
   essential.
+- After adding, renaming, or removing a plugin skill, run
+  `make sync-codex-skills` to update `.codex/skills/` and commit the result.
+  `make test` fails if the symlinks drift from `plugins/*/skills/`.
 
 ## Commands and verification
 
 Run relevant checks before handing off changes:
 
 ```bash
-make test       # Hook tests
-make validate   # Plugin manifest, scripts, and dependencies
-make lint       # ShellCheck/Markdown lint when installed
+make test              # Hook tests, marketplace and Codex symlink consistency
+make validate           # Plugin manifest, scripts, and dependencies
+make lint               # ShellCheck/Markdown lint when installed
+make sync-codex-skills  # Regenerate .codex/skills/ after plugin skill changes
 ```
 
 `jq`, `grep`, `awk`, and `mktemp` are required for the security-hook tooling.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,13 +31,14 @@ The repository is organized as a **marketplace with 7 installable plugins**:
 All project operations are managed through the Makefile:
 
 ```bash
-make test           # Run complete test suite
-make lint           # Run ShellCheck on all shell scripts
-make install        # Install hooks (make scanner script executable)
-make clean          # Remove test artifacts and logs
-make status         # Show current status and configuration
-make check-tools    # Check for required and optional security tools
-make help           # Display all available commands
+make test               # Run complete test suite
+make lint               # Run ShellCheck on all shell scripts
+make install            # Install hooks (make scanner script executable)
+make sync-codex-skills  # Sync .codex/skills symlinks with plugins/*/skills
+make clean              # Remove test artifacts and logs
+make status             # Show current status and configuration
+make check-tools        # Check for required and optional security tools
+make help               # Display all available commands
 ```
 
 ## Claude Code Skills and Commands
@@ -154,6 +155,8 @@ The project uses Claude Code's PreToolUse hook mechanism with two complementary 
 - `plugins/*/commands/`: Legacy slash commands (check, clean, changelog)
 - `tests/test-scanner.sh`: Security scanner test suite
 - `tests/test-protect-main-branch.sh`: Protected branch hook test suite
+- `tests/test-codex-skills.sh`: Verifies `.codex/skills/` symlinks match `plugins/*/skills/`
+- `scripts/sync-codex-skills.sh`: Creates, fixes, and prunes `.codex/skills/` symlinks (`--check` for CI/verification)
 - `Makefile`: Primary interface for all project operations
 - `docs/mcp-security-scanner.md`: Comprehensive security scanner documentation
 - `docs/protect-main-branch-hook.md`: Comprehensive branch protection documentation

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,9 @@ MANIFEST_FILE := $(PLUGIN_DIR)/.claude-plugin/plugin.json
 TEST_SCRIPT := $(TESTS_DIR)/test-scanner.sh
 TEST_PROTECT_BRANCH_SCRIPT := $(TESTS_DIR)/test-protect-main-branch.sh
 TEST_MARKETPLACE_SCRIPT := $(TESTS_DIR)/test-marketplace.sh
+TEST_CODEX_SKILLS_SCRIPT := $(TESTS_DIR)/test-codex-skills.sh
 VALIDATE_SCRIPT := $(SCRIPTS_DIR)/validate-config.sh
+SYNC_CODEX_SKILLS_SCRIPT := $(SCRIPTS_DIR)/sync-codex-skills.sh
 
 # Pinned tool versions
 CLAUDELINT_VERSION := 0.7.1
@@ -48,6 +50,9 @@ test: ## Run complete test suite
 	@echo
 	@echo -e "$(BLUE)🧪 Running marketplace consistency tests...$(NC)"
 	@$(TEST_MARKETPLACE_SCRIPT)
+	@echo
+	@echo -e "$(BLUE)🧪 Running Codex skill symlink tests...$(NC)"
+	@$(TEST_CODEX_SKILLS_SCRIPT)
 
 .PHONY: validate
 validate: ## Validate plugin manifest, hook scripts, and dependencies
@@ -105,6 +110,10 @@ clean: ## Remove test artifacts and logs
 	@find "$(PLUGIN_DIR)" -name "*.log" -type f -delete 2>/dev/null || true
 	@find "$(TESTS_DIR)" -name "*.log" -type f -delete 2>/dev/null || true
 	@echo -e "$(GREEN)✅ Cleanup complete$(NC)"
+
+.PHONY: sync-codex-skills
+sync-codex-skills: ## Sync .codex/skills symlinks with plugins/*/skills
+	@$(SYNC_CODEX_SKILLS_SCRIPT)
 
 ##@ Development
 
@@ -167,6 +176,7 @@ help: ## Display this help
 	@echo "  make validate          # Validate plugin configuration"
 	@echo "  make lint              # Run code quality checks"
 	@echo "  make install           # Make hook scripts executable"
+	@echo "  make sync-codex-skills # Sync .codex/skills symlinks with plugins/*/skills"
 	@echo "  make clean             # Clean up artifacts"
 	@echo
 

--- a/scripts/sync-codex-skills.sh
+++ b/scripts/sync-codex-skills.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+
+# Sync Codex Skill Symlinks
+#
+# .codex/skills/<name> exposes each plugins/<plugin>/skills/<name> directory
+# to Codex. This script keeps those symlinks in sync with the plugin skills
+# actually on disk: creating missing links, fixing links that point at the
+# wrong plugin, and removing links for skills that no longer exist.
+#
+# Usage:
+#   scripts/sync-codex-skills.sh          # apply changes
+#   scripts/sync-codex-skills.sh --check  # report drift, change nothing
+
+# Deliberately no -e: this script's contract is to evaluate every skill and
+# report every problem in one run, not abort on the first one.
+set -uo pipefail
+shopt -s nullglob
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly PROJECT_ROOT
+cd "$PROJECT_ROOT" || exit 1
+
+readonly PLUGINS_DIR="plugins"
+readonly CODEX_SKILLS_DIR=".codex/skills"
+
+CHECK_MODE=false
+case "${1:-}" in
+    --check)
+        CHECK_MODE=true
+        ;;
+    -h | --help)
+        echo "Usage: $0 [--check]"
+        echo "  --check   Report drift without modifying $CODEX_SKILLS_DIR (exit 1 if any is found)"
+        exit 0
+        ;;
+    "") ;;
+    *)
+        echo "Unknown option: $1" >&2
+        exit 1
+        ;;
+esac
+
+ACTIONS=0
+ERRORS=0
+
+# Records an action taken (or, in --check mode, an action that would be
+# taken) and prints it, so the same code path drives both modes.
+note() {
+    if [[ "$CHECK_MODE" == true ]]; then
+        echo "  would $1"
+    else
+        echo "  $1"
+    fi
+    ACTIONS=$((ACTIONS + 1))
+}
+
+# --- Discover the desired symlink set from plugins/*/skills/* --------------
+
+declare -A desired_target
+declare -A desired_plugin
+
+for skills_dir in "$PLUGINS_DIR"/*/skills; do
+    plugin="$(basename "$(dirname "$skills_dir")")"
+    for skill_dir in "$skills_dir"/*/; do
+        name="$(basename "$skill_dir")"
+        if [[ -n "${desired_plugin[$name]:-}" && "${desired_plugin[$name]}" != "$plugin" ]]; then
+            echo "ERROR: skill '$name' is defined by both '${desired_plugin[$name]}' and '$plugin'" >&2
+            ERRORS=$((ERRORS + 1))
+            continue
+        fi
+        desired_target[$name]="../../$PLUGINS_DIR/$plugin/skills/$name"
+        desired_plugin[$name]="$plugin"
+    done
+done
+
+if [[ $ERRORS -gt 0 ]]; then
+    echo "Aborting: resolve the skill name collision(s) above before syncing." >&2
+    exit 1
+fi
+
+if [[ ! -d "$CODEX_SKILLS_DIR" ]]; then
+    if [[ "$CHECK_MODE" == true ]]; then
+        note "create directory: $CODEX_SKILLS_DIR"
+    else
+        mkdir -p "$CODEX_SKILLS_DIR"
+    fi
+fi
+
+# --- Create or fix a link for every desired skill ---------------------------
+
+for name in "${!desired_target[@]}"; do
+    link_path="$CODEX_SKILLS_DIR/$name"
+    target="${desired_target[$name]}"
+
+    if [[ -L "$link_path" ]]; then
+        current_target="$(readlink "$link_path")"
+        if [[ "$current_target" != "$target" ]]; then
+            note "fix: $link_path -> $target (was $current_target)"
+            if [[ "$CHECK_MODE" == false ]]; then
+                rm -f "$link_path"
+                ln -s "$target" "$link_path"
+            fi
+        fi
+    elif [[ -e "$link_path" ]]; then
+        echo "ERROR: $link_path exists and is not a symlink; refusing to overwrite" >&2
+        ERRORS=$((ERRORS + 1))
+    else
+        note "create: $link_path -> $target"
+        [[ "$CHECK_MODE" == true ]] || ln -s "$target" "$link_path"
+    fi
+done
+
+# --- Remove links for skills that no longer exist ---------------------------
+
+for link_path in "$CODEX_SKILLS_DIR"/*; do
+    name="$(basename "$link_path")"
+    [[ -n "${desired_target[$name]:-}" ]] && continue
+
+    if [[ -L "$link_path" ]]; then
+        note "remove: $link_path"
+        [[ "$CHECK_MODE" == true ]] || rm -f "$link_path"
+    else
+        echo "WARNING: $link_path is not a symlink; leaving it in place" >&2
+    fi
+done
+
+if [[ $ERRORS -gt 0 ]]; then
+    exit 1
+fi
+
+if [[ "$CHECK_MODE" == true ]]; then
+    if [[ $ACTIONS -gt 0 ]]; then
+        echo
+        echo "$ACTIONS change(s) needed. Run: scripts/sync-codex-skills.sh" >&2
+        exit 1
+    fi
+    echo "✅ $CODEX_SKILLS_DIR is in sync with $PLUGINS_DIR/*/skills"
+    exit 0
+fi
+
+if [[ $ACTIONS -gt 0 ]]; then
+    echo "✅ $CODEX_SKILLS_DIR synced ($ACTIONS change(s))"
+else
+    echo "✅ $CODEX_SKILLS_DIR already in sync"
+fi

--- a/tests/test-codex-skills.sh
+++ b/tests/test-codex-skills.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# Codex Skill Symlink Tests
+#
+# .codex/skills/* must mirror plugins/*/skills/* exactly, so Codex never
+# sees a stale or missing skill. scripts/sync-codex-skills.sh --check is the
+# single source of truth for what "in sync" means; this just wraps its
+# result in the project's usual pass/fail test output.
+
+set -uo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$PROJECT_ROOT" || exit 1
+
+readonly SYNC_SCRIPT="scripts/sync-codex-skills.sh"
+
+PASSED=0
+FAILED=0
+
+pass() {
+    echo "  ✓ $1"
+    PASSED=$((PASSED + 1))
+}
+
+fail() {
+    echo "  ✗ $1"
+    FAILED=$((FAILED + 1))
+}
+
+echo "🧪 Codex Skill Symlink Tests"
+echo "============================"
+echo
+
+if [[ ! -x "$SYNC_SCRIPT" ]]; then
+    echo "❌ $SYNC_SCRIPT is missing or not executable"
+    exit 1
+fi
+
+if output="$("$SYNC_SCRIPT" --check 2>&1)"; then
+    pass ".codex/skills is in sync with plugins/*/skills"
+else
+    fail ".codex/skills is out of sync with plugins/*/skills (run: $SYNC_SCRIPT)"
+    echo "    ${output//$'\n'/$'\n'    }"
+fi
+
+echo
+echo "================================"
+echo "Results: $PASSED passed, $FAILED failed"
+
+if [[ $FAILED -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary
- add repository-level Codex guidance in AGENTS.md
- expose all plugin skills through .codex/skills symlinks
- preserve plugin skill directories as the single source of truth

## Validation
- verified all 12 plugin skills resolve through .codex/skills
- git diff --check