### PR TITLE
feat: add shell-script-reviewer skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,9 +27,9 @@
     {
       "name": "dev-skills",
       "source": "./plugins/dev-skills",
-      "description": "Expert development skills for Go, documentation, architecture, and project management",
+      "description": "Expert development skills for Go, documentation, architecture, shell scripting, and project management",
       "version": "1.0.0",
-      "keywords": ["skills", "go", "documentation", "architecture", "mentorship"],
+      "keywords": ["skills", "go", "documentation", "architecture", "mentorship", "shell", "bash"],
       "category": "skills"
     },
     {

--- a/.codex/skills/shell-script-reviewer
+++ b/.codex/skills/shell-script-reviewer
@@ -1,0 +1,1 @@
+../../plugins/dev-skills/skills/shell-script-reviewer

--- a/docs/MARKETPLACE.md
+++ b/docs/MARKETPLACE.md
@@ -65,10 +65,11 @@ claude code plugins install security-hooks
 - `/manager` - Project orchestration
 - `/specify` - Technical specifications
 - `/taskify` - Task decomposition
+- `/shell-script-reviewer` - Bash/Zsh/Fish script review
 
 **Features**:
 
-- 7 specialized development skills
+- 8 specialized development skills
 - Expert knowledge in Go, documentation, and architecture
 - Project management and task coordination
 

--- a/plugins/dev-skills/.claude-plugin/plugin.json
+++ b/plugins/dev-skills/.claude-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "dev-skills",
-  "description": "Expert development skills for Go, documentation, architecture, and project management",
+  "description": "Expert development skills for Go, documentation, architecture, shell scripting, and project management",
   "version": "1.0.0",
   "author": {
     "name": "Richard Claydon"
   },
   "license": "MPL-2.0",
-  "keywords": ["skills", "go", "documentation", "architecture", "mentorship"],
+  "keywords": ["skills", "go", "documentation", "architecture", "mentorship", "shell", "bash"],
   "skills": ["./skills/"]
 }

--- a/plugins/dev-skills/README.md
+++ b/plugins/dev-skills/README.md
@@ -52,6 +52,12 @@ Task decomposition expert for breaking technical specifications into atomic, imp
 
 **Use when**: Converting specs into actionable task lists for development teams.
 
+### `/shell-script-reviewer`
+
+Reviews Bash, Zsh, and Fish shell scripts for bugs, security vulnerabilities, portability issues, and style violations, grounded in the Google Shell Style Guide, ShellCheck, BashPitfalls, and shell-specific idiom references.
+
+**Use when**: Reviewing, auditing, linting, or improving a `.sh`/`.bash`/`.zsh`/`.fish` file.
+
 ## Installation
 
 Install via Claude Code marketplace:
@@ -95,6 +101,9 @@ claude code plugins install github:rikdc/ai-skills/dev-skills
 
 # Debug a Go concurrency issue
 /golang-expert Why is my worker pool leaking goroutines?
+
+# Review a shell script
+/shell-script-reviewer Review scripts/deploy.sh for security issues
 ```
 
 ## License

--- a/plugins/dev-skills/skills/shell-script-reviewer/SKILL.md
+++ b/plugins/dev-skills/skills/shell-script-reviewer/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: shell-script-reviewer
+description: Reviews Bash, Zsh, and Fish shell scripts for bugs, security vulnerabilities, portability issues, and style violations against the Google Shell Style Guide, ShellCheck, BashPitfalls, and shell-specific idiom conventions. Use when the user asks to review, audit, lint, or improve a .sh/.bash/.zsh/.fish file, or pastes shell script content for feedback.
+user-invocable: true
+argument-hint: "[file_or_dir] [--security] [--fix]"
+allowed-tools: Read, Glob, Grep, Bash(shellcheck:*), Bash(shfmt:*), Bash(fish:*), Bash(git diff:*), Bash(git log:*), Bash(find:*)
+---
+
+# Shell Script Reviewer
+
+You are a **shell script reviewer** grounded in named authorities rather
+than ad-hoc opinion: the Google Shell Style Guide for structure, ShellCheck
+for static analysis, Greg's Wiki BashPitfalls for defensive scripting, and
+a dedicated security checklist. Bash, Zsh, and Fish diverge meaningfully in
+syntax and semantics — never apply a Bash idiom to Zsh or Fish without
+checking the shell-specific reference first.
+
+**Error-handling stance**: flag `set -e`/`set -u` (or Zsh's
+`ERR_EXIT`/`NO_UNSET`) as an anti-pattern when present, not as something
+to require when absent — keep `pipefail`. Full reasoning in
+`references/bash-pitfalls.md`; don't contradict it.
+
+## Reference files
+
+Load only the file(s) relevant to the current script — don't read all of
+them for a small Bash script:
+
+| Topic | File | When to read |
+|-------|------|--------------|
+| Bash style/structure | `references/bash-style-guide.md` | Any Bash script — formatting, quoting, naming, `main` pattern, when shell is the wrong tool |
+| ShellCheck codes | `references/shellcheck-codes.md` | Explaining/prioritizing ShellCheck findings for Bash/sh; also covers ShellCheck's blind spots |
+| Bash pitfalls + error handling | `references/bash-pitfalls.md` | Runtime bugs ShellCheck under-explains, and this skill's explicit-checks-over-`set -e`/`-u` stance |
+| Security | `references/security-checklist.md` | Every review, every dialect — read this one unconditionally |
+| Fish | `references/fish-guide.md` | Any `.fish` file or fish shebang |
+| Zsh | `references/zsh-guide.md` | Any `.zsh` file or zsh shebang |
+
+## Step 1: Identify the dialect
+
+Run the detector against the target file:
+
+```bash
+scripts/detect_shell.sh <file>
+```
+
+(Resolve the path relative to this skill's own directory — the script
+inspects the shebang first, then extension, then sniffs for
+dialect-specific syntax as a last resort.) If it reports `unknown` or
+`sh`, and the ambiguity matters (e.g. the file mixes bashisms with a `sh`
+shebang), ask the user which dialect they intend, or infer from context
+(array usage, `function` keyword, `set`/`end` blocks) and state the
+assumption in your output.
+
+Route to the correct reference file(s) for that dialect before doing
+anything else.
+
+## Step 2: Run static analysis first when possible
+
+- **Bash/sh**: run `scripts/run_shellcheck.sh <file> [bash|sh]` and
+  `scripts/run_shfmt_check.sh <file>`. Treat ShellCheck's output as ground
+  truth for the codes it covers — don't re-derive a rule ShellCheck
+  already flagged, explain and prioritize its actual findings instead
+  (cross-reference `references/shellcheck-codes.md` for the fix pattern).
+- **Zsh**: run `scripts/run_shellcheck.sh <file> bash` as a best-effort
+  approximation for portable constructs only. Explicitly call out
+  Zsh-specific constructs it cannot validate (word-splitting differences,
+  1-based arrays, `setopt` behavior) and rely on
+  `references/zsh-guide.md` for those.
+- **Fish**: ShellCheck does not apply. If `fish` is available, run
+  `fish -n <file>` for syntax-only validation. All substantive review is
+  manual, driven by `references/fish-guide.md`.
+- If a tool isn't installed, the wrapper scripts report that plainly —
+  note it in your output as reduced coverage rather than silently skipping
+  the category.
+
+## Step 3: Apply manual review categories, in this priority order
+
+### a. Security (highest priority)
+
+Read `references/security-checklist.md` unconditionally. Check for:
+`eval` on untrusted input, unquoted expansions of external input,
+predictable temp file paths (vs. `mktemp` + `trap EXIT`), credentials in
+argv/env, missing input validation/allowlisting, unsafe `PATH`
+assumptions, unnecessary root/SUID execution.
+
+### b. Correctness / robustness
+
+Unchecked exit statuses on critical operations — `cd`, destructive
+`rm`/`mv`/`cp`, a build/deploy step — are always a finding, independent of
+whether `set -e` is present (see the error-handling stance above and
+`references/bash-pitfalls.md`). Also check: incorrect word-splitting
+assumptions for the dialect in use; parsing `ls` output; TOCTOU race
+conditions in check-then-act file operations. Fish has no errexit
+equivalent at all — for `.fish` files check `$status`/`and`/`or` usage per
+`references/fish-guide.md` instead.
+
+### c. Portability
+
+Shebang correctness vs. actual syntax used (e.g. bashisms under
+`#!/bin/sh` — ShellCheck SC3045 and friends); shell-version-dependent
+features; assumptions about GNU vs. BSD utility flags; Zsh scripts relying
+on default word-splitting/glob behavior that would break under `sh`
+emulation or Bash.
+
+### d. Style / maintainability
+
+Indentation consistency, quoting conventions, naming conventions,
+function structure and the `main`/`main "$@"` pattern (Bash), documentation
+completeness, line length, and script length — flag scripts near or over
+~100 lines as candidates for a rewrite in a structured language, per the
+Google Shell Style Guide's own guidance in `references/bash-style-guide.md`.
+
+## Step 4: Output format
+
+For each finding, report:
+
+- **Location**: `file:line`
+- **Severity**: Critical / High / Medium / Low
+- **Category**: one of Security, Correctness, Portability, Style (from
+  Step 3)
+- **Explanation**: one sentence on the actual risk in this script's
+  context, not a generic restatement of the rule
+- **Fix**: a concrete before/after code snippet
+
+Group findings by severity, security/critical issues first. End with a
+short summary count table by severity and by category.
+
+**Do not silently auto-fix.** Always show the proposed diff for user
+approval, unless the user explicitly asked you to apply fixes directly
+(e.g. via `--fix`) — and even then, summarize what changed after applying.
+
+### Output skeleton
+
+```markdown
+## Shell Script Review: <file>
+
+**Dialect**: bash | zsh | fish  **Lines**: <n>
+**Static analysis**: shellcheck (n findings) | shfmt (drift: yes/no) | not available
+
+### Critical
+#### 1. <title>
+**Severity**: Critical | **Category**: Security
+**Location**: `file:line`
+**Risk**: <one sentence>
+**Current**:
+\`\`\`bash
+...
+\`\`\`
+**Fix**:
+\`\`\`bash
+...
+\`\`\`
+
+### High
+...
+### Medium
+...
+### Low
+...
+
+### Summary
+| Severity | Count |
+|----------|-------|
+| Critical | n |
+| High | n |
+| Medium | n |
+| Low | n |
+
+| Category | Count |
+|----------|-------|
+| Security | n |
+| Correctness | n |
+| Portability | n |
+| Style | n |
+```
+
+## Step 5: Escalation rule
+
+If ShellCheck and manual review disagree, or a construct's safety depends
+on a runtime value ShellCheck can't see (dynamic `eval` targets, indirect
+variable references, values crossing into an embedded `awk`/`sed`/SQL
+snippet), **flag it as "needs runtime verification"** rather than
+asserting certainty either way, and recommend a BATS test case that
+exercises the risky path with adversarial input.
+
+## Task execution
+
+Based on `$ARGUMENTS`:
+
+- **A file or directory is given**: review it (recurse for a directory,
+  one report per file plus a combined summary).
+- **`--security` is given**: narrow the review to Step 3a only, but still
+  run static analysis first.
+- **`--fix` is given**: after presenting findings and getting
+  confirmation, apply fixes in this order, then re-run static analysis to
+  confirm, then report a summary of what changed:
+  1. ShellCheck's own suggested fixes (Bash/sh only):
+     `scripts/run_shellcheck.sh <file> <dialect> diff | patch -p1`
+  2. Formatting: `shfmt -w -i 2 -ci -bn -sr -- <file>`
+  3. Hand-apply the remaining findings that neither tool can fix
+     (security issues, `-e`/`-u` removal plus the explicit checks that
+     replace them, anything flagged "needs runtime verification").
+- **Script content is pasted with no file**: write it to a temp file
+  (`mktemp`, matching the dialect's extension) for the static-analysis
+  tools to run against, then review as normal; clean up the temp file
+  afterward.
+- **Nothing specified**: review unstaged/staged shell script changes via
+  `git diff` (filter to `*.sh`, `*.bash`, `*.zsh`, `*.fish` paths).
+
+Your goal is to **ground every finding in a named authority** (Google
+Shell Style Guide, a specific ShellCheck code, BashPitfalls, or the
+security checklist) so feedback is actionable and verifiable, not a matter
+of taste — and to be explicit about the difference between "ShellCheck
+confirmed this" and "this needs a human/runtime check" for the dialects
+and constructs static analysis can't fully cover.

--- a/plugins/dev-skills/skills/shell-script-reviewer/evals.json
+++ b/plugins/dev-skills/skills/shell-script-reviewer/evals.json
@@ -1,0 +1,220 @@
+{
+  "description": "Test cases for shell-script-reviewer. Each case's script should be written to a temp file with the given extension and reviewed per SKILL.md. expected_findings defines the minimum bar for recall (every listed finding must be surfaced, at >= the given severity); must_not_exceed_severity is a precision check for the clean cases; must_not_mention is a policy check -- e.g. verifying the reviewer never recommends adding set -e/set -u, since this skill treats their presence as a finding rather than their absence.",
+  "cases": [
+    {
+      "id": "bash-unquoted-injection",
+      "dialect": "bash",
+      "extension": ".sh",
+      "focus": "unquoted variable injection risk",
+      "script": "#!/bin/bash\n# Deletes a user-provided list of files.\ncleanup() {\n  local files=$1\n  rm -rf $files\n}\n\ncleanup \"$1\"\n",
+      "expected_findings": [
+        {
+          "category": "security",
+          "severity": "Critical",
+          "shellcheck_code": "SC2086",
+          "must_mention_any": ["word splitting", "word-splitting", "unquoted", "SC2086"],
+          "reason": "$files is unquoted in rm -rf $files; a value like '* --no-preserve-root' or multiple space-separated paths expands to unintended targets"
+        }
+      ]
+    },
+    {
+      "id": "bash-missing-error-checks",
+      "dialect": "bash",
+      "extension": ".sh",
+      "focus": "unchecked critical commands -- no set -e present, and none should be recommended",
+      "script": "#!/bin/bash\nBUILD_DIR=build\ncd $BUILD_DIR\nrm -rf ./*\nmkdir artifacts\ncp ../dist/* artifacts/\necho \"done\"\n",
+      "expected_findings": [
+        {
+          "category": "correctness",
+          "severity": "High",
+          "shellcheck_code": "SC2164",
+          "must_mention_any": ["cd", "fails", "|| exit"],
+          "reason": "cd $BUILD_DIR has no failure check; if it fails, rm -rf ./* runs in the original directory"
+        },
+        {
+          "category": "correctness",
+          "severity": "Medium",
+          "must_mention_any": ["explicit", "|| exit", "exit status", "check"],
+          "reason": "mkdir and cp have no explicit exit-status checks; a failure in either is silently ignored and the script reports 'done' regardless"
+        }
+      ],
+      "must_not_mention": ["add set -e", "add set -euo pipefail", "recommend set -e"],
+      "note": "the fix here is explicit per-command checks, not adding a strict-mode header -- this skill flags -e/-u as an anti-pattern, so the review must not recommend adding them"
+    },
+    {
+      "id": "bash-unsafe-eval",
+      "dialect": "bash",
+      "extension": ".sh",
+      "focus": "unsafe eval on untrusted input",
+      "script": "#!/bin/bash\n# Runs a named build step.\nstep=\"$1\"\neval \"run_$step\"\n\nrun_build() { echo building; }\nrun_test() { echo testing; }\n",
+      "expected_findings": [
+        {
+          "category": "security",
+          "severity": "Critical",
+          "must_mention_any": ["eval", "arbitrary", "injection", "allowlist"],
+          "reason": "eval \"run_$step\" executes attacker-controlled shell code if $step contains shell metacharacters (e.g. 'build; rm -rf /')"
+        }
+      ]
+    },
+    {
+      "id": "bash-style-noncompliant-but-correct",
+      "dialect": "bash",
+      "extension": ".sh",
+      "focus": "stylistically non-compliant but functionally correct",
+      "script": "#!/bin/bash\nset -o pipefail\nDir=\"$1\"\nCount=`ls \"$Dir\" | wc -l`\nif [ \"$Count\" -gt 0 ]\nthen\n\techo \"Found $Count files\"\nfi\n",
+      "expected_findings": [
+        {
+          "category": "style",
+          "severity": "Low",
+          "must_mention_any": ["backtick", "SC2006", "naming", "lowercase"],
+          "reason": "backticks instead of $(...), PascalCase variable names instead of lowercase_with_underscores, then/do not on the same line as if"
+        }
+      ],
+      "must_not_exceed_severity": "Medium",
+      "note": "quoting is already correct and only pipefail (this skill's recommended baseline, no -e/-u) is present, so nothing here should be scored Critical or High"
+    },
+    {
+      "id": "bash-strict-mode-anti-pattern",
+      "dialect": "bash",
+      "extension": ".sh",
+      "focus": "set -euo pipefail present with no explicit checks -- should itself be flagged under this skill's policy",
+      "script": "#!/bin/bash\nset -euo pipefail\ninput_dir=\"$1\"\noutput_dir=\"$2\"\nmkdir -p \"$output_dir\"\ncp \"$input_dir\"/*.log \"$output_dir\"/\necho \"copied logs\"\n",
+      "expected_findings": [
+        {
+          "category": "style",
+          "severity": "Low",
+          "must_mention_any": ["set -e", "set -u", "explicit", "pipefail"],
+          "reason": "set -euo pipefail is present with no explicit per-command checks of its own; per this skill's convention, -e/-u should be removed in favor of explicit `cmd || exit` checks -- set -o pipefail alone is fine to keep"
+        }
+      ],
+      "must_not_exceed_severity": "Medium",
+      "note": "everything else in this script is already correct (quoting, no destructive unguarded glob, no eval) -- this case exists specifically to verify the reviewer flags -e/-u presence itself rather than treating it as a good practice"
+    },
+    {
+      "id": "zsh-unquoted-injection",
+      "dialect": "zsh",
+      "extension": ".zsh",
+      "focus": "unquoted expansion injection risk that survives zsh's word-splitting defaults",
+      "script": "#!/usr/bin/env zsh\ntargets=(\"$@\")\nfor t in ${targets[@]}; do\n  rsync -a $t /backup/\ndone\n",
+      "expected_findings": [
+        {
+          "category": "security",
+          "severity": "High",
+          "must_mention_any": ["quote", "${targets[@]}", "$t", "array expansion"],
+          "reason": "array expansions and $t are unquoted; array-element splitting still applies in zsh regardless of SH_WORD_SPLIT, and a path with a leading '-' could be parsed as an rsync flag"
+        }
+      ]
+    },
+    {
+      "id": "zsh-missing-error-checks",
+      "dialect": "zsh",
+      "extension": ".zsh",
+      "focus": "no explicit error handling on critical commands -- setopt ERR_EXIT/NO_UNSET should not be the recommended fix",
+      "script": "#!/usr/bin/env zsh\nsource ./env.zsh\ndeploy_dir=$DEPLOY_DIR/current\ncd $deploy_dir\n./release.sh\n",
+      "expected_findings": [
+        {
+          "category": "correctness",
+          "severity": "High",
+          "must_mention_any": ["cd", "explicit", "check", "|| exit"],
+          "reason": "cd $deploy_dir has no explicit failure check; if it fails, ./release.sh still runs from the original directory"
+        }
+      ],
+      "must_not_mention": ["add setopt ERR_EXIT", "add setopt NO_UNSET", "recommend ERR_EXIT"],
+      "note": "the fix is an explicit cd || exit check, not a setopt ERR_EXIT/NO_UNSET header -- this skill flags those as an anti-pattern"
+    },
+    {
+      "id": "zsh-unsafe-eval",
+      "dialect": "zsh",
+      "extension": ".zsh",
+      "focus": "unsafe eval on untrusted input",
+      "script": "#!/usr/bin/env zsh\nfilter=\"$1\"\neval \"find . -name '$filter'\"\n",
+      "expected_findings": [
+        {
+          "category": "security",
+          "severity": "Critical",
+          "must_mention_any": ["eval", "injection", "arbitrary"],
+          "reason": "$filter is interpolated into a string passed to eval; a value like ''' -o -exec rm -rf {} ; ''' breaks out of the intended find invocation"
+        }
+      ]
+    },
+    {
+      "id": "zsh-style-noncompliant-but-correct",
+      "dialect": "zsh",
+      "extension": ".zsh",
+      "focus": "stylistically non-compliant but functionally correct, includes a 0-index assumption note",
+      "script": "#!/usr/bin/env zsh\nsetopt PIPE_FAIL\narr=(alpha beta gamma)\nfirst=$arr[1]\necho \"first element: $first\"\n",
+      "expected_findings": [
+        {
+          "category": "style",
+          "severity": "Low",
+          "must_mention_any": ["indexed", "1-indexed", "readability", "quote"],
+          "reason": "correct 1-indexed usage for zsh but unquoted $arr[1] access and no comment noting the indexing differs from bash for readers porting code"
+        }
+      ],
+      "must_not_exceed_severity": "Medium",
+      "note": "arr[1] correctly returns 'alpha' in zsh (1-indexed) -- reviewer must not flag this as an off-by-one bug. Only PIPE_FAIL is set (no ERR_EXIT/NO_UNSET), matching this skill's recommended baseline, so that should not be flagged either"
+    },
+    {
+      "id": "fish-unquoted-injection",
+      "dialect": "fish",
+      "extension": ".fish",
+      "focus": "unquoted expansion used to build a destructive command",
+      "script": "#!/usr/bin/env fish\nset target $argv[1]\nrm -rf $target/*\n",
+      "expected_findings": [
+        {
+          "category": "security",
+          "severity": "Critical",
+          "must_mention_any": ["quote", "\\$target", "empty", "validate"],
+          "reason": "no validation that $argv[1] was actually provided; an empty $target makes rm -rf $target/* equivalent to rm -rf /*"
+        }
+      ]
+    },
+    {
+      "id": "fish-missing-strict-mode",
+      "dialect": "fish",
+      "extension": ".fish",
+      "focus": "missing $status checks -- fish has no errexit equivalent",
+      "script": "#!/usr/bin/env fish\nmkdir /tmp/build\ncd /tmp/build\ntar xf archive.tar.gz\n./configure\nmake\n",
+      "expected_findings": [
+        {
+          "category": "correctness",
+          "severity": "High",
+          "must_mention_any": ["\\$status", "and", "or", "errexit"],
+          "reason": "no $status checks or and/or chaining after mkdir/cd/tar; fish has no set -e equivalent so failures are silently ignored and later commands run in the wrong state"
+        }
+      ]
+    },
+    {
+      "id": "fish-unsafe-eval",
+      "dialect": "fish",
+      "extension": ".fish",
+      "focus": "unsafe eval on untrusted input",
+      "script": "#!/usr/bin/env fish\nset cmd $argv[1]\neval $cmd\n",
+      "expected_findings": [
+        {
+          "category": "security",
+          "severity": "Critical",
+          "must_mention_any": ["eval", "arbitrary", "injection", "allowlist"],
+          "reason": "fish's eval builtin executes $cmd as shell code; passing it directly from argv is arbitrary command execution"
+        }
+      ]
+    },
+    {
+      "id": "fish-style-noncompliant-but-correct",
+      "dialect": "fish",
+      "extension": ".fish",
+      "focus": "stylistically non-compliant but functionally correct",
+      "script": "#!/usr/bin/env fish\nfunction GetCount\nset f $argv[1]\nset c (cat $f | wc -l | string trim)\necho $c\nend\nGetCount data.txt\n",
+      "expected_findings": [
+        {
+          "category": "style",
+          "severity": "Low",
+          "must_mention_any": ["snake_case", "naming", "indent", "builtin"],
+          "reason": "PascalCase function name instead of snake_case, no indentation inside the function body, and shells out to cat/wc where fish's own tooling (or wc alone via redirection) would suffice"
+        }
+      ],
+      "must_not_exceed_severity": "Medium",
+      "note": "cat $f | wc -l works correctly here; this is a style-only finding, not a correctness bug"
+    }
+  ]
+}

--- a/plugins/dev-skills/skills/shell-script-reviewer/references/bash-pitfalls.md
+++ b/plugins/dev-skills/skills/shell-script-reviewer/references/bash-pitfalls.md
@@ -1,0 +1,151 @@
+# Bash Pitfalls and Strict-Mode Guidance
+
+Primary source for the pitfalls below: https://mywiki.wooledge.org/BashPitfalls
+— treat it as the canonical secondary reference alongside ShellCheck
+(`shellcheck-codes.md`) for Bash-specific runtime bugs that static analysis
+sometimes under-explains.
+
+## High-value pitfalls to check for
+
+- **`for f in $(ls ...)` / any command-substitution loop over filenames.**
+  Word-splits on whitespace and glob-expands the result — mangles
+  filenames with spaces, globs, or newlines. Use a glob (`for f in *.mp3`)
+  or `find ... -print0 | while IFS= read -r -d '' f`. (ShellCheck SC2045,
+  SC2044.)
+
+- **Unquoted parameter/command-substitution expansions everywhere**
+  (`$var`, `$(cmd)`, `$@`). This is the single most common source of bugs
+  in the wild — quote by default, only leave something unquoted with a
+  comment explaining why splitting is intentional. (ShellCheck SC2086,
+  SC2046, SC2068.)
+
+- **`cd` without a failure check.** An unhandled failed `cd` leaves the
+  rest of the script running in the wrong directory — dangerous right
+  before any `rm`, `mv`, or write. Always `cd dir || exit` (or `|| return`
+  inside a function). (ShellCheck SC2164.)
+
+- **Exporting `CDPATH`.** An exported `CDPATH` changes where a script's own
+  `cd` calls land, and can leak into command substitution output in older
+  shells. Never export it in a script; unset it defensively if the script
+  must be robust against a polluted environment: `unset CDPATH` near the
+  top.
+
+- **`cmd1 | while read ...`** — the loop body runs in a subshell (in
+  Bash), so variables it sets or side effects it has (e.g., incrementing a
+  counter) vanish once the pipeline exits. Use process substitution
+  instead: `while read -r line; do ...; done < <(cmd1)`.
+
+- **Reading input without `IFS=` and `-r`.** Plain `read line` trims
+  leading/trailing whitespace per the default `IFS` and mangles
+  backslashes. Use `IFS= read -r line` when the line must be preserved
+  exactly.
+
+- **Locale-dependent multibyte handling in `read -d ''`.** Under certain
+  locales, null-delimited reads can behave unexpectedly with multibyte
+  characters. Prefer `LC_ALL=C` for byte-oriented parsing loops that must
+  be locale-independent.
+
+- **`[ ]` with unquoted operands** (`[ $x = y ]`). If `$x` is empty or
+  contains spaces, this either throws a "unary operator expected" error or
+  silently misparses. Use `[[ $x = y ]]` (no splitting/globbing inside
+  `[[ ]]`) or quote inside `[ ]`: `[ "$x" = y ]`.
+
+- **Array element expansion in destructive contexts** (e.g., array index
+  or values used inside `rm`, `eval`, or arithmetic contexts) without
+  validating they're actually numeric/expected — this is a functional
+  injection risk when the array is populated from external input. See
+  `security-checklist.md`.
+
+- **Redirection order.** `cmd 2>&1 >>logfile` does **not** redirect stderr
+  to the log file — redirections apply left to right, and at the point
+  `2>&1` runs, `1` is still the terminal. Use `cmd >>logfile 2>&1`.
+
+- **Backticks instead of `$(...)`.** Nesting and escaping inside backticks
+  is genuinely broken in edge cases; `$(...)` is strictly better and has
+  been portable for well over a decade. (ShellCheck SC2006.)
+
+## Error handling: explicit checks over `set -e`/`set -u`
+
+A widely-cited pattern is the "unofficial Bash strict mode" header:
+
+```bash
+set -euo pipefail
+IFS=$'\n\t'
+```
+
+**This skill does not recommend `-e` (errexit) or `-u` (nounset) as a
+baseline for every script.** Keep `-o pipefail` and the `IFS` narrowing —
+they're unambiguously safe defense in depth. Treat `-e`/`-u` as an
+anti-pattern to flag when present, not a best practice to require when
+absent, for the reasons below.
+
+- **`-o pipefail`** — a pipeline's exit status becomes the last non-zero
+  status among its stages, instead of always being the last stage's
+  status. Without it, `false | true` "succeeds". Keep this.
+- **`IFS=$'\n\t'`** — narrows word-splitting to newline and tab only, so
+  an accidentally-unquoted expansion doesn't also split on spaces. Defense
+  in depth, not a substitute for quoting. Keep this.
+- **`-e` (errexit)** — exits immediately if a simple command exits
+  non-zero, but its rules for *which* commands count are notoriously
+  inconsistent (see below). Scripts that lean on `-e` for correctness
+  develop false confidence: the header looks like error handling but
+  silently no-ops on exactly the commands an author is most likely to
+  wrap in a condition or a helper function.
+- **`-u` (nounset)** — turns a reference to an unset variable into a
+  runtime error, but only on the exact code path that happens to execute.
+  It can't catch an unset-variable bug on a branch that isn't exercised in
+  this run. ShellCheck (SC2086, SC2154) catches the same class of bug
+  statically, across every branch, at review time — before the script
+  ever runs.
+
+### Why `-e` is unreliable
+
+- **Does not fire inside a command substitution used in a condition**,
+  e.g. `if [ "$(false)" ]` — the inner failure is swallowed because it's
+  the condition of an `if`, not a standalone statement.
+- **Does not fire for any command that is part of an `&&`/`||` list**, or
+  the condition of `if`/`while`/`until`, or preceded by `!`. This includes
+  calling a function that itself contains a "critical" failing command —
+  the failure is suppressed at the call site, not just the immediate
+  command.
+- **Does not fire for any command in a pipeline** except, with
+  `pipefail`, affecting the pipeline's overall status — and even then
+  only where that overall status is actually checked.
+
+### Why `-u` isn't a substitute for review
+
+- **Coverage is runtime-only and path-dependent** — a bug on an untaken
+  branch stays hidden indefinitely.
+- **Empty arrays misbehave on Bash < 4.4**: `"${arr[@]}"` for a
+  zero-element array raised a spurious unbound-variable error on older
+  Bash versions, which trains authors to work around `-u` rather than
+  trust it.
+
+### What to actually flag
+
+- **`set -e`/`set -u` present** (bare or as part of `set -euo pipefail`):
+  Low/Medium **Style** finding — recommend removing `-e`/`-u`, keeping
+  `-o pipefail`, and replacing whatever error handling `-e` was standing
+  in for with explicit checks (below). This is a maintainability finding,
+  not a safety one — don't score it above Medium by itself.
+- **Any critical command with no explicit exit-status check** — `cd`,
+  destructive `rm`/`mv`/`cp`, a build/deploy step whose failure should
+  stop the script — is a **Correctness** finding regardless of whether
+  `-e` is present, because `-e` cannot be trusted to catch it reliably
+  (see above). This is the primary way this skill scores error handling,
+  not "does the script have a strict-mode header."
+- **Missing `set -o pipefail`/`setopt PIPE_FAIL`** on a script with a
+  pipeline whose failure matters is still its own finding.
+
+The explicit-check alternative:
+
+```bash
+cd "$deploy_dir" || exit 1
+mkdir -p "$out_dir" || { echo "mkdir failed" >&2; exit 1; }
+build_artifact || exit 1
+```
+
+This is more verbose than a one-line strict-mode header, but every check
+is visible at the call site and behaves the same whether the failing
+command is top-level, inside a function, or inside a conditional —
+exactly the cases where `-e` silently does nothing.

--- a/plugins/dev-skills/skills/shell-script-reviewer/references/bash-pitfalls.md
+++ b/plugins/dev-skills/skills/shell-script-reviewer/references/bash-pitfalls.md
@@ -1,6 +1,6 @@
 # Bash Pitfalls and Strict-Mode Guidance
 
-Primary source for the pitfalls below: https://mywiki.wooledge.org/BashPitfalls
+Primary source for the pitfalls below: <https://mywiki.wooledge.org/BashPitfalls>
 — treat it as the canonical secondary reference alongside ShellCheck
 (`shellcheck-codes.md`) for Bash-specific runtime bugs that static analysis
 sometimes under-explains.

--- a/plugins/dev-skills/skills/shell-script-reviewer/references/bash-style-guide.md
+++ b/plugins/dev-skills/skills/shell-script-reviewer/references/bash-style-guide.md
@@ -1,6 +1,6 @@
 # Bash Style Guide (condensed from Google Shell Style Guide)
 
-Source of truth: https://google.github.io/styleguide/shellguide.html — cite
+Source of truth: <https://google.github.io/styleguide/shellguide.html> — cite
 this when a finding is a style violation rather than deriving rules ad hoc.
 
 ## When shell is (and isn't) the right choice
@@ -104,11 +104,11 @@ this when a finding is a style violation rather than deriving rules ad hoc.
   multi-line output — one block instead of N statements:
 
   ```bash
-  # Good
+  # Good (every indent below is a literal tab, not spaces)
   cat <<- EOF
-  	Something
-  	${variable}
-  	EOF
+  <TAB>Something
+  <TAB>${variable}
+  <TAB>EOF
 
   # Avoid
   echo "Something"
@@ -117,7 +117,9 @@ this when a finding is a style violation rather than deriving rules ad hoc.
 
   `<<-` strips **leading tabs** (not spaces) from the body and the closing
   marker, which is what allows the here-doc to be indented with the
-  surrounding code.
+  surrounding code. (`<TAB>` above stands in for an actual tab character —
+  written literally here to survive markdown linting, which rejects real
+  tab characters in this repo.)
 - Quote the marker (`<<- 'EOF'`) when the body must **not** have variables
   or command substitutions expanded — e.g. emitting literal `$` text.
 - If tab-based indentation doesn't work for the context, fall back to an

--- a/plugins/dev-skills/skills/shell-script-reviewer/references/bash-style-guide.md
+++ b/plugins/dev-skills/skills/shell-script-reviewer/references/bash-style-guide.md
@@ -1,0 +1,191 @@
+# Bash Style Guide (condensed from Google Shell Style Guide)
+
+Source of truth: https://google.github.io/styleguide/shellguide.html — cite
+this when a finding is a style violation rather than deriving rules ad hoc.
+
+## When shell is (and isn't) the right choice
+
+- Shell is acceptable for small utilities and simple wrapper scripts.
+- If a script is **primarily calling other utilities with little data
+  manipulation**, shell is fine even if it's longer.
+- If the script exceeds roughly **100 lines**, or starts using non-straightforward
+  control flow / data structures, **rewrite it in a structured language**
+  (Python, Go, etc.) instead of continuing to grow it. Flag scripts near or
+  over this threshold as a maintainability finding, not a hard blocker.
+- Never write performance-critical code in shell.
+
+## File structure
+
+- Executables should have a `.sh` extension or none at all (bare name);
+  libraries meant to be sourced **must** have a `.sh` extension and **must
+  not** be executable, per Google's guide. (Some codebases instead use a
+  `.bash` extension for sourced-only files to make "this is a library, not
+  an entry point" visible at a glance — either is fine as long as the
+  project is consistent; follow the project's own stated convention over
+  this default when one exists.)
+- Start every executable with `#!/bin/bash` (not `/bin/sh`, not `env bash`
+  unless the environment truly requires PATH-based lookup) and minimal flags
+  on the shebang line.
+- Immediately after the shebang, put a top-of-file comment describing the
+  script's purpose.
+- Use `set -o pipefail` near the top. **Don't** reach for `set -e`/`set -u`
+  as a blanket safety net — this skill treats their presence as a finding,
+  not their absence; see [[bash-pitfalls]] for why, and use explicit
+  per-command exit-status checks instead.
+- If the script has more than one function, define a `main` function and
+  call `main "$@"` as the **last line of the file**. This keeps top-level
+  execution order obvious and testable.
+- For a script meant to be both executable *and* sourceable (so its
+  functions can be unit-tested by sourcing the file without triggering
+  `main`), guard the `main` call:
+
+  ```bash
+  main() {
+    ...
+  }
+
+  if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+  fi
+  ```
+
+## Formatting
+
+- **2-space indentation**, no tabs.
+- Maximum line length **80 characters** where reasonably achievable.
+- `; then` and `; do` go on the **same line** as `if`/`for`/`while`:
+
+  ```bash
+  if [[ -f "${file}" ]]; then
+    ...
+  fi
+
+  for arg in "$@"; do
+    ...
+  done
+  ```
+
+- Pipelines that don't fit on one line: one segment per line, `|` at the end
+  of the line, continuation lines indented.
+- Use `[[ ... ]]` in preference to `[ ... ]` or `test` — it doesn't
+  word-split or glob its operands and supports `&&`/`||`/`=~` directly.
+- Use `(( ... ))` for numeric comparisons, not `[[ $x -gt 10 ]]`:
+  `(( value > 10 ))` reads closer to the comparison it performs and avoids
+  the `-gt`/`-lt`/`-eq` operator vocabulary entirely.
+- Prefer `$(command)` for command substitution; never use backticks
+  (nesting and escaping are error-prone).
+
+## Quoting
+
+- **Quote all expansions**: `"${var}"`, `"$1"`, `"$(command)"`. Unquoted
+  expansions are the single most common source of word-splitting and
+  globbing bugs (ShellCheck SC2086 — see [[shellcheck-codes]]).
+- Prefer `"${var}"` over `"$var"` for clarity, especially when adjacent to
+  other text.
+- Use `'single quotes'` for literal strings with no expansion, `"double
+  quotes"` for strings needing variable or command expansion.
+- Arrays for anything that is conceptually a list, especially argument
+  lists to be passed to another command — never build a single
+  space-joined string and rely on word-splitting to re-separate it.
+
+  ```bash
+  # Good
+  local -a flags=(--verbose --output "${outfile}")
+  some_command "${flags[@]}"
+
+  # Bad: relies on word-splitting, breaks on paths with spaces
+  local flags="--verbose --output ${outfile}"
+  some_command ${flags}
+  ```
+
+## Heredocs and multi-line output
+
+- Prefer a tab-indented here-doc over a run of `echo`/`printf` calls for
+  multi-line output — one block instead of N statements:
+
+  ```bash
+  # Good
+  cat <<- EOF
+  	Something
+  	${variable}
+  	EOF
+
+  # Avoid
+  echo "Something"
+  echo "${variable}"
+  ```
+
+  `<<-` strips **leading tabs** (not spaces) from the body and the closing
+  marker, which is what allows the here-doc to be indented with the
+  surrounding code.
+- Quote the marker (`<<- 'EOF'`) when the body must **not** have variables
+  or command substitutions expanded — e.g. emitting literal `$` text.
+- If tab-based indentation doesn't work for the context, fall back to an
+  unindented here-doc (`<< EOF`, no dash, no leading tabs), or redirect a
+  whole `{ ...; }` block when a here-doc doesn't fit the shape of the
+  output:
+
+  ```bash
+  {
+    echo "Something"
+    echo "Something else"
+  } >> "${GITHUB_OUTPUT}"
+  ```
+
+## Idioms
+
+- **Regex as a separate variable before `=~`**: assign the pattern to a
+  variable first rather than inlining it, to sidestep quoting ambiguity
+  (ShellCheck SC2076 — quoting the right-hand side of `=~` silently turns
+  it into a literal match) and version-dependent parsing differences in
+  older Bash:
+
+  ```bash
+  # Good
+  local re='^[0-9]+$'
+  if [[ "${var}" =~ ${re} ]]; then
+
+  # Avoid
+  if [[ "${var}" =~ ^[0-9]+$ ]]; then
+  ```
+
+- **Bash built-ins over external commands** where one exists — `[[ =~ ]]`
+  instead of piping to `grep`, parameter expansion (`${var//x/y}`) instead
+  of `sed` for simple substitutions (ShellCheck SC2001). Fewer subprocess
+  spawns, and the logic stays inline instead of round-tripping through a
+  pipe.
+- **Prefer long-form flags on invoked commands** (`jq --raw-output` over
+  `jq -r`) when the tool supports them — readability at the call site over
+  brevity. This is a house-style preference, not a correctness issue: flag
+  it at most Low severity, and don't apply it to flags so common they're
+  effectively their own vocabulary (`rm -f`, `ls -la`).
+
+## Naming
+
+- **Functions and local variables**: lowercase with underscores,
+  `my_func`, `my_var`. Prefer `local` for all function-scoped variables.
+- **Constants and environment/exported variables**: uppercase with
+  underscores, `readonly MAX_RETRIES=3`, declared at the top of the file
+  right after the header comment.
+- **Package/library-style filenames**: lowercase with underscores.
+- Function names use `::` as a namespace separator for libraries only when
+  needed to avoid collisions (`mypackage::my_func`); don't invent this for
+  a single-purpose script.
+
+## Comments
+
+- File header comment states the script's purpose.
+- Function header comments describe purpose, globals used/modified, args,
+  and outputs/return value for any non-trivial function — mirror the "why",
+  not a restatement of the code.
+
+## Common structural smells to flag
+
+- Missing `main`/`main "$@"` pattern in a script with 3+ functions.
+- Deeply nested conditionals that would read better as early returns
+  (`continue`/`return` guard clauses).
+- Global mutable state read/written from many functions instead of being
+  passed as arguments.
+- A script that has clearly outgrown shell (heavy string/data manipulation,
+  JSON parsing beyond `jq` one-liners, anything needing real data
+  structures) — recommend a rewrite rather than further shell patches.

--- a/plugins/dev-skills/skills/shell-script-reviewer/references/fish-guide.md
+++ b/plugins/dev-skills/skills/shell-script-reviewer/references/fish-guide.md
@@ -1,0 +1,145 @@
+# Fish Shell Review Guide
+
+Fish is **not POSIX-compatible** and diverges from Bash/Zsh in ways that
+make Bash idioms actively wrong if copied uncritically. ShellCheck does
+not support Fish at all — this file, plus manual inspection and `fish -n`
+(syntax-only check), is the entire toolchain for Fish review. There is no
+Fish equivalent of the Google Shell Style Guide; conventions below are
+drawn from Fish's own documentation and community-established practice
+(fish-shell GitHub issue discussion), not a single ratified standard —
+treat style (not correctness) findings here as advisory.
+
+## Variables are always lists
+
+Every Fish variable is a list, even a "scalar":
+
+```fish
+set name Alice          # a one-element list
+set names Alice Bob Cy  # a three-element list
+echo $name[1]            # 1-indexed, not 0-indexed
+echo $names[2]            # Bob
+echo $names[-1]           # Cy — negative indices count from the end
+```
+
+**Review implication**: code that assumes `$var` is always a single value
+(e.g., using it directly in a numeric comparison without considering it
+could be empty or multi-element after a command substitution) is a
+correctness risk. `set x (some command)` captures each output line as a
+separate list element, not a single string — check whether that's
+actually what the author wants.
+
+## No `errexit` — you must check status explicitly
+
+**This is the single most important Bash-to-Fish trap.** Fish has no
+`set -e` equivalent for "exit the script on any command failure."
+`set -e VARNAME` in Fish means **erase this variable** — it has nothing to
+do with error handling. A script author porting Bash strict-mode habits
+and writing `set -e` at the top of a Fish script has written a no-op (or
+a bug, if a variable named that way happens to exist).
+
+Correct patterns for error handling in Fish:
+
+```fish
+# Check $status (fish's equivalent of $?) explicitly
+mkdir /some/dir
+if test $status -ne 0
+    echo "mkdir failed" >&2
+    exit 1
+end
+
+# Or use and/or chaining
+mkdir /some/dir; and cd /some/dir; or exit 1
+```
+
+**Review checklist**: for any script doing multiple sequential operations
+where a failure should stop execution, verify each critical step either
+checks `$status` or is chained with `and`/`or` — flag scripts that assume
+Bash-style implicit errexit.
+
+## Scope flags, not `local`/`export`
+
+Fish variable scope is set at declaration time via flags to `set`, not via
+separate `local`/`export`/`global` keywords:
+
+| Flag | Scope |
+|------|-------|
+| `-l` / `--local` | Current block (function or `begin...end`) |
+| `-f` / `--function` | Entire enclosing function, even in nested blocks |
+| `-g` / `--global` | Global to the current shell session |
+| `-U` / `--universal` | Persisted across all sessions for the user (survives restarts) |
+| `-x` / `--export` | Exported to the environment of child processes (combine with a scope flag, e.g. `-lx`) |
+
+**Review checklist**: functions that write to variables with no scope flag
+(bare `set var value`) default to function scope if the variable doesn't
+already exist in an outer scope, or overwrite the outer variable if it
+does — this is a common source of accidental global mutation. Prefer
+explicit `-l` inside functions. Flag `-U` (universal) used for anything
+that isn't genuinely meant to persist across terminal sessions — it's easy
+to reach for by mistake and creates surprising state that outlives the
+script.
+
+## Quoting and word-splitting differences
+
+- Unquoted variable expansion of a list spreads each element as a separate
+  argument — similar to Bash's `"$@"` — but Fish **does not** perform
+  IFS-style word-splitting or glob-expand the *contents* of a variable the
+  way Bash does. A value containing a space stays one list element unless
+  it came from a multi-line command substitution.
+- Command substitution `(cmd)` splits output into a list **by line** by
+  default. Wrap in `string collect` (or use `(cmd | string collect)`) when
+  the output must be treated as a single string rather than split.
+- Quoting a variable (`"$var"`) forces it to behave like a single string,
+  joining list elements with spaces — this is closer to Bash's `"$*"` than
+  `"$@"`. Getting quoted vs. unquoted backwards is the Fish analogue of a
+  Bash missing-quotes bug: it changes whether downstream commands see one
+  argument or several.
+- Globs (`*`, `**`) are expanded when they appear literally in a command;
+  they are **not** re-expanded out of variable contents, which removes a
+  whole class of Bash injection-via-unquoted-glob risk — but don't treat
+  this as blanket safety; validate input before using it in filesystem
+  operations regardless.
+
+## Avoid Bash syntax leakage
+
+Common tells that Bash habits leaked into a Fish script (all invalid or
+wrong in Fish):
+
+- `if [ ... ]; then` / `fi` — Fish uses `if ... ; end` (no `then`,
+  closing keyword is `end` for every block, not `fi`/`done`/`esac`).
+- `$(cmd)` — Fish uses `(cmd)` for command substitution (no `$`).
+  `$(cmd)` will not do what the author expects.
+- `export VAR=value` — Fish uses `set -gx VAR value`.
+- `function ... { ... }` with braces — Fish functions are
+  `function name ... end`, no braces.
+- `$?` — Fish uses `$status`.
+- `&&` / `||` — valid in modern Fish as of a few releases, but the
+  idiomatic and universally-supported form is `and`/`or`. Flag as a
+  portability note (not a hard error) if the script targets older Fish.
+
+## Style conventions (community-established, not official)
+
+No canonical style guide exists for Fish. Discussion in the fish-shell
+issue tracker (github.com/fish-shell/fish-shell#1838, #2703) has
+converged informally on:
+
+- 4-space indentation.
+- `snake_case` for function and variable names.
+- ~80-character line length as a soft target.
+- Prefer Fish builtins (`string`, `math`, `path`) over shelling out to
+  external `sed`/`awk`/`bc`/`expr` for simple text/number operations.
+- Wrap reusable logic in functions rather than repeating command
+  sequences; put shared functions under `functions/` for autoloading if
+  the script is part of a larger Fish configuration.
+
+Treat violations of these as **Low severity style** findings, distinct
+from the Fish correctness issues above (`set -e` confusion, missing
+`$status` checks, scope-flag mistakes), which should be scored as
+correctness/robustness findings per `SKILL.md`.
+
+## Available tooling
+
+- `fish -n script.fish` — syntax-only check (parses without executing).
+  This is the closest Fish equivalent to a linter available by default;
+  it catches parse errors but not the semantic issues above.
+- No direct Fish equivalent of `shfmt` is in common use; formatting
+  consistency must be checked manually against the conventions above.

--- a/plugins/dev-skills/skills/shell-script-reviewer/references/security-checklist.md
+++ b/plugins/dev-skills/skills/shell-script-reviewer/references/security-checklist.md
@@ -1,0 +1,110 @@
+# Shell Script Security Checklist
+
+Security findings are always **highest priority** — surface them before
+correctness, portability, or style findings (see `SKILL.md` step 3).
+
+## Injection prevention
+
+- **Never pass untrusted/external input to `eval`.** `eval` re-parses its
+  argument as shell code, so any user-controlled substring becomes
+  arbitrary command execution. If dynamic dispatch is genuinely needed,
+  use an allowlisted `case` statement mapping known values to actions, or
+  an associative array of function references — never string-build a
+  command and `eval` it.
+
+  ```bash
+  # PROBLEM: attacker-controlled $action becomes arbitrary code
+  eval "$action"
+
+  # FIX: allowlist
+  case "$action" in
+    start|stop|restart) "$action" ;;
+    *) echo "unknown action: $action" >&2; exit 1 ;;
+  esac
+  ```
+
+- **Quote every expansion of external input** — command-line args,
+  environment variables, file contents, command output. Unquoted
+  expansion is a word-splitting/globbing bug (see `bash-pitfalls.md`,
+  ShellCheck SC2086/SC2046) and, when the split pieces are then passed to
+  another command, it can become an argument-injection vector (e.g.
+  smuggling in an unexpected `-e` or `--option` flag).
+
+- **Validate all external input against an allowlist, not a blocklist.**
+  Blocklisting specific bad characters/strings is always incomplete;
+  define what a valid value looks like (regex, fixed set of values, numeric
+  range) and reject anything else.
+
+- **Don't build SQL, `awk`/`sed` programs, or other embedded-language code
+  by interpolating shell variables into a string that's then executed.**
+  Same injection class as `eval`. Pass values as separate arguments/bind
+  parameters where the underlying tool supports it.
+
+## Temp files
+
+- **Never use a predictable temp file path** (`/tmp/myscript.$$`,
+  `/tmp/myscript.tmp`). Predictable names in a world-writable directory
+  are vulnerable to symlink races and pre-creation attacks (TOCTOU).
+- **Always use `mktemp`/`mktemp -d`** to create temp files/dirs with a
+  random, race-free name and safe permissions.
+- **Always clean up with `trap ... EXIT`** so the temp file/dir is removed
+  even on error paths or early exit — don't rely on cleanup at the bottom
+  of the script running.
+
+  ```bash
+  tmpdir=$(mktemp -d) || exit 1
+  trap 'rm -rf -- "$tmpdir"' EXIT
+  ```
+
+## Credentials
+
+- **Never pass secrets as command-line arguments.** Arguments are visible
+  to any other user on the system via `ps`, `/proc/<pid>/cmdline`, and
+  process accounting logs. Use environment variables (still visible to the
+  same UID, but not to other users via `ps`), a file with restricted
+  permissions, or a secrets-manager integration instead.
+- **Restrict permissions on any file containing credentials**
+  (`chmod 600`), and set a restrictive `umask` before creating it rather
+  than creating it world-readable and fixing permissions after (a race
+  window exists between creation and the `chmod`).
+- **Don't echo/log secrets**, including via `set -x`/`bash -x` tracing
+  left enabled in production, or via error messages that include the full
+  command line.
+
+## Least privilege
+
+- **Drop elevated privileges immediately after the operation that needs
+  them**, rather than running the rest of the script as root/setuid.
+- **Avoid unnecessary root/SUID execution.** If only one operation in the
+  script needs elevation, isolate it (e.g., a single `sudo` call for that
+  line) rather than requiring the whole script to run privileged.
+- Flag any script that requires root but doesn't clearly document why, or
+  that could be rewritten to need elevation for only part of its work.
+
+## `PATH` and executable resolution
+
+- **Sanitize `PATH` explicitly** in scripts run via cron, setuid contexts,
+  or on behalf of other users — don't inherit an untrusted caller's
+  `PATH`. Set it explicitly near the top:
+  `PATH=/usr/local/bin:/usr/bin:/bin`.
+- **Use absolute paths for security-sensitive commands** (anything
+  involved in privilege changes, file permission changes, or destructive
+  operations) rather than relying on `PATH` lookup, so a malicious
+  earlier-in-PATH binary can't be substituted.
+
+## Additional checks
+
+- **Race conditions (TOCTOU)** — a `[ -e file ]` check followed by a
+  separate operation on `file` has a window where the file can change
+  underneath the script. Prefer atomic operations (`mkdir` for lockfiles,
+  `mktemp` for temp files, `ln` for atomic rename-based locks) over
+  check-then-act.
+- **Command injection via filenames** — a filename beginning with `-` can
+  be interpreted as a flag by the next command it's passed to (ShellCheck
+  SC2035). Use `--` or `./` prefixes.
+- **World-writable directories** — creating any file in `/tmp` or another
+  shared directory without `mktemp`'s race-free creation is a symlink
+  attack vector.
+- **Don't trust `$0`, `argv[0]`, or the script's own path** for anything
+  security-sensitive; these are attacker-influenced when the script is
+  invoked in unusual ways.

--- a/plugins/dev-skills/skills/shell-script-reviewer/references/shellcheck-codes.md
+++ b/plugins/dev-skills/skills/shell-script-reviewer/references/shellcheck-codes.md
@@ -1,0 +1,52 @@
+# ShellCheck Code Reference
+
+Curated from https://www.shellcheck.net/wiki/ — treat these as ground truth
+for Bash/POSIX findings. When ShellCheck reports one of these, cite the
+code, explain the risk in the script's actual context, and show the fix;
+don't re-derive the rule from scratch.
+
+| Code | Title | Cause | Risk | Fix |
+|------|-------|-------|------|-----|
+| SC2086 | Double quote to prevent globbing and word splitting | Unquoted expansion of `$var`, `$1`, `$*`/`$@` | Word-splitting on IFS and glob expansion break the script on inputs with spaces or glob characters | Quote it: `"$var"`, `"$1"`, `"$@"` |
+| SC2046 | Quote this to prevent word splitting | Unquoted command substitution `$(cmd)` | Same word-splitting/globbing risk, applied to command output | Quote it: `"$(cmd)"`; if splitting is genuinely wanted, use `read -a` or `mapfile` instead |
+| SC2155 | Declare and assign separately to avoid masking return values | `local`/`export`/`readonly` combined with `var=$(cmd)` in one statement | The declaration's exit status overwrites the command substitution's exit status, so `$?` and `set -e` see the wrong result | Split into two statements: `local var; var=$(cmd)` |
+| SC2164 | Use `cd ... \|\| exit` in case `cd` fails | `cd` called with no failure handling | A failed `cd` (bad path, permissions, broken symlink) leaves later commands running in the wrong directory — dangerous before `rm`/writes | `cd dir \|\| exit`, `cd dir \|\| return`, or wrap in `if cd dir; then ... fi` |
+| SC2045 | Iterating over `ls` output is fragile. Use globs | `for f in $(ls *.ext)` | Breaks on filenames with spaces, newlines, or glob characters; `ls` output was never meant to be parsed | `for f in *.ext; do [[ -e "$f" ]] \|\| break; ...; done` |
+| SC3045 | Shell built-in flags unsupported in POSIX sh | bash-only flags (`read -e`, `export -f`, `wait -n`, etc.) used under a `sh`/`dash` shebang | Script fails or behaves differently when actually run under `dash`/POSIX sh despite the shebang claiming portability | Change the shebang to `#!/bin/bash` if the feature is needed, or rewrite with a POSIX-portable equivalent |
+| SC1036 | `(` is invalid here | Literal `(` used where shell syntax expects a word, often `(cmd)` instead of `$(cmd)`, or non-shell syntax copied in | Script fails to parse | Use `$(cmd)` for substitution, quote literal parens, or remove them for a plain function call |
+| SC2181 | Check exit code directly, not indirectly with `$?` | `cmd; if [ $? -eq 0 ]; then` | An intervening command (even `echo`) silently changes what `$?` refers to; also fights `set -e` | `if cmd; then` / `if ! cmd; then`; for captured output: `if ! out=$(cmd); then` |
+| SC2068 | Double quote array expansions | Unquoted `$@` or `${array[@]}` | Each element is re-split and glob-expanded instead of passed through as one argument each | Quote it: `"$@"`, `"${array[@]}"` |
+| SC2034 | Variable appears unused | A variable is assigned but never read | Usually a typo (wrong name referenced elsewhere) or genuinely dead code | Fix the typo, use `_` for intentional throwaways, or `# shellcheck disable=SC2034` with a reason if it's read indirectly |
+| SC2115 | Use `"${var:?}"` to ensure this never expands to `/*` | Unguarded variable in a destructive path, e.g. `rm -rf "$root/"*` | If `$root` is empty or unset, the command becomes `rm -rf /*` — catastrophic data loss | `rm -rf "${root:?}/"*` so an empty/unset variable aborts instead of expanding |
+| SC2006 | Use `$(...)` instead of backticks | Legacy `` `cmd` `` substitution | Backtick quoting/escaping rules are inconsistent and nesting is painful and error-prone | Replace with `$(cmd)` |
+| SC2001 | Consider parameter expansion instead of `sed` | `echo "$var" \| sed 's/x/y/'` for a simple substitution | Unnecessary subprocess and pipe for something Bash can do natively | `"${var/x/y}"` (first match) or `"${var//x/y}"` (all matches) |
+| SC2148 | Add a shebang | No `#!` line, so ShellCheck (and the OS) can't determine the target shell | Shell-specific advice can't be given, and direct execution depends on the caller's default shell | Add `#!/bin/bash` (or the correct interpreter) as line 1 |
+| SC2035 | Use `./*glob*` or `-- *glob*` | Bare glob like `rm *` where a matched filename can start with `-` | A file named e.g. `-f` gets parsed as a flag instead of a filename | `rm ./*` or `rm -- *` |
+| SC2076 | Don't quote the right-hand side of `=~` | `[[ $x =~ "^foo$" ]]` | Quoting forces literal string matching instead of regex — the pattern silently stops being a regex | Drop the quotes and escape special characters instead: `[[ $x =~ ^foo$ ]]` |
+| SC2016 | Expressions don't expand in single quotes | `$var` or `$(cmd)` written inside `'...'` | Output is the literal text `$var`, not its value — usually not what was intended | Use double quotes if expansion is wanted; keep single quotes (and silence the warning) if the literal text is intentional |
+| SC1091 | Not following sourced file | ShellCheck can't resolve a `source`/`.` target (missing file, not passed on the command line, dynamic path) | Bugs inside the sourced file go unchecked | Add `# shellcheck source=path/to/file`, or `source=/dev/null` if it's genuinely unavailable to the checker |
+| SC2166 | Avoid `-a`/`-o` in `[ ]` | `[ p -a q ]` / `[ p -o q ]` | POSIX deprecated these — behavior is ambiguous once arguments contain `-` or `!` | `[ p ] && [ q ]` / `[ p ] || [ q ]` |
+| SC2129 | Consolidate multiple redirects | Repeated `cmd >> file` for a sequence of commands | Reopens the file for every command; unnecessarily slow and can interact oddly with traps | Group the commands and redirect once: `{ cmd1; cmd2; cmd3; } >> file` |
+| SC2059 | Don't put variables in printf's format string | `printf "$msg\n"` | If `$msg` contains `%` or backslash escapes, printf misinterprets them | `printf '%s\n' "$msg"` |
+| SC2236 | Use `-n`/`-z` directly instead of `! -z`/`! -n` | `[ ! -z "$x" ]` | Purely a readability nit — double negative | `[ -n "$x" ]` |
+
+## Limits of ShellCheck coverage
+
+ShellCheck is static analysis: it cannot evaluate runtime-constructed
+values. Do not treat "ShellCheck found nothing" as "this construct is
+safe" for:
+
+- `eval` with any input that isn't a fixed string literal.
+- Dynamic command names built from variables (`"$cmd" "$@"` where `$cmd` is
+  user-influenced).
+- Indirect variable references / `${!name}`.
+- Anything inside a string handed to a different interpreter (e.g. an
+  embedded `awk`/`sed`/`sql` snippet with interpolated shell variables).
+
+Flag these as "needs runtime verification" per the escalation rule in
+`SKILL.md`, and recommend a BATS test rather than asserting safety.
+
+ShellCheck also has **no native Zsh dialect**. Running it with
+`--shell=bash` against a Zsh script is a best-effort approximation for
+portable constructs only — see `zsh-guide.md` for what it will miss.
+ShellCheck **does not support Fish at all** — see `fish-guide.md`.

--- a/plugins/dev-skills/skills/shell-script-reviewer/references/shellcheck-codes.md
+++ b/plugins/dev-skills/skills/shell-script-reviewer/references/shellcheck-codes.md
@@ -1,6 +1,6 @@
 # ShellCheck Code Reference
 
-Curated from https://www.shellcheck.net/wiki/ — treat these as ground truth
+Curated from <https://www.shellcheck.net/wiki/> — treat these as ground truth
 for Bash/POSIX findings. When ShellCheck reports one of these, cite the
 code, explain the risk in the script's actual context, and show the fix;
 don't re-derive the rule from scratch.
@@ -25,7 +25,7 @@ don't re-derive the rule from scratch.
 | SC2076 | Don't quote the right-hand side of `=~` | `[[ $x =~ "^foo$" ]]` | Quoting forces literal string matching instead of regex — the pattern silently stops being a regex | Drop the quotes and escape special characters instead: `[[ $x =~ ^foo$ ]]` |
 | SC2016 | Expressions don't expand in single quotes | `$var` or `$(cmd)` written inside `'...'` | Output is the literal text `$var`, not its value — usually not what was intended | Use double quotes if expansion is wanted; keep single quotes (and silence the warning) if the literal text is intentional |
 | SC1091 | Not following sourced file | ShellCheck can't resolve a `source`/`.` target (missing file, not passed on the command line, dynamic path) | Bugs inside the sourced file go unchecked | Add `# shellcheck source=path/to/file`, or `source=/dev/null` if it's genuinely unavailable to the checker |
-| SC2166 | Avoid `-a`/`-o` in `[ ]` | `[ p -a q ]` / `[ p -o q ]` | POSIX deprecated these — behavior is ambiguous once arguments contain `-` or `!` | `[ p ] && [ q ]` / `[ p ] || [ q ]` |
+| SC2166 | Avoid `-a`/`-o` in `[ ]` | `[ p -a q ]` / `[ p -o q ]` | POSIX deprecated these — behavior is ambiguous once arguments contain `-` or `!` | `[ p ] && [ q ]` / `[ p ] \|\| [ q ]` |
 | SC2129 | Consolidate multiple redirects | Repeated `cmd >> file` for a sequence of commands | Reopens the file for every command; unnecessarily slow and can interact oddly with traps | Group the commands and redirect once: `{ cmd1; cmd2; cmd3; } >> file` |
 | SC2059 | Don't put variables in printf's format string | `printf "$msg\n"` | If `$msg` contains `%` or backslash escapes, printf misinterprets them | `printf '%s\n' "$msg"` |
 | SC2236 | Use `-n`/`-z` directly instead of `! -z`/`! -n` | `[ ! -z "$x" ]` | Purely a readability nit — double negative | `[ -n "$x" ]` |

--- a/plugins/dev-skills/skills/shell-script-reviewer/references/zsh-guide.md
+++ b/plugins/dev-skills/skills/shell-script-reviewer/references/zsh-guide.md
@@ -1,0 +1,122 @@
+# Zsh Review Guide
+
+Zsh is close enough to Bash that authors often copy Bash idioms wholesale,
+but several defaults differ in ways that change both correctness and the
+risk profile of "missing quotes" bugs. **ShellCheck has no native Zsh
+dialect** — `run_shellcheck.sh` can be pointed at a Zsh file with
+`--shell=bash` as a best-effort check of portable constructs only (see
+`shellcheck-codes.md`); treat anything Zsh-specific as needing manual
+review against this guide instead.
+
+## Word-splitting differs from Bash by default
+
+In native Zsh emulation, **unquoted parameter expansion of a scalar does
+not word-split and does not glob-expand** the way it does in Bash:
+
+```zsh
+var="a b c"
+for x in $var; do echo "$x"; done
+# Bash: prints a / b / c  (three iterations — word split)
+# Zsh:  prints "a b c"    (one iteration — no split by default)
+```
+
+This is controlled by the `SH_WORD_SPLIT` option (off by default in native
+Zsh; on automatically when Zsh is invoked as `sh`/`ksh`) and `GLOB_SUBST`
+(off by default — parameter-expansion results aren't re-interpreted as
+glob patterns).
+
+**Review implication — this changes but does not eliminate injection
+risk**: a script relying on this default behaves safely for the classic
+"unquoted variable with spaces breaks into multiple arguments" bug, but:
+
+- The script becomes **non-portable** — the exact same unquoted code
+  behaves differently if the file is ever run under `sh`, `bash`, or Zsh
+  in `sh`-emulation mode. Flag unquoted expansions as a portability
+  finding even when Zsh's native behavior happens to be safe.
+- **`$@`, `"$@"`, positional parameters, and array expansions
+  (`${array[@]}`) still split into multiple words** regardless of
+  `SH_WORD_SPLIT` — those are inherently list-valued, not a scalar being
+  split. Bugs here (missing quotes around `${array[@]}`) still apply.
+- Command substitution `$(cmd)` still splits on whitespace/newlines by
+  default in list contexts, same general shape as Bash.
+- Still quote everything by default — don't let a reviewer or author use
+  "Zsh doesn't split" as a reason to skip quoting; it's a portability and
+  clarity issue even when not an immediate correctness bug.
+
+## Arrays are 1-indexed by default
+
+```zsh
+arr=(a b c)
+echo $arr[1]   # "a" in Zsh (vs. would be unset/empty in Bash, where
+               # arr[1] is the *second* element)
+```
+
+`setopt KSH_ARRAYS` switches to 0-indexed, Bash-style arrays for
+compatibility scripts. **Review checklist**: confirm the author isn't
+mixing 0-indexed assumptions (common when porting from Bash) into a script
+that hasn't set `KSH_ARRAYS` — an off-by-one here is silent, not an error.
+
+## `NOMATCH` — unmatched globs abort by default
+
+Zsh's default behavior for a glob pattern that matches nothing is to
+**print "no matches found" and abort** (non-interactive scripts exit
+non-zero), unlike Bash, which leaves an unmatched glob as the literal
+pattern text. A script ported from Bash that relies on an unmatched glob
+silently passing through as a literal string will break under Zsh.
+
+- `setopt NO_NOMATCH` restores Bash-like "leave it literal" behavior.
+- `setopt NULL_GLOB` makes an unmatched glob disappear entirely (expands
+  to nothing) instead of erroring — matches Bash's `shopt -s nullglob`.
+- The `(N)` glob qualifier applies null-glob behavior to a single glob
+  expression without changing global shell options: `*.txt(N)`.
+
+Flag any script using globs without considering which of these behaviors
+it actually wants, especially scripts intended to be portable to/from
+Bash.
+
+## Extended globbing risks
+
+With `setopt EXTENDED_GLOB`, Zsh glob patterns gain significant power:
+`^pattern` (negation), `pattern~exclude` (exclude), `(#i)` (case
+insensitive), recursive `**/`, and more. This is useful but means a
+string the author thinks is a plain literal (containing `^`, `~`, `#`, or
+`(`) can be silently reinterpreted as a glob expression once
+`EXTENDED_GLOB` is active. Review checklist:
+
+- Is `EXTENDED_GLOB` actually needed, or could the script use a narrower,
+  explicit approach (`string.gsub`-equivalent tooling, `case` patterns)?
+- Are values that might contain these special characters (filenames from
+  user input, external data) ever used unquoted where extended globbing
+  is active?
+
+## Error handling: explicit checks over `ERR_EXIT`/`NO_UNSET`
+
+This mirrors the Bash stance in `bash-pitfalls.md`: keep `PIPE_FAIL`,
+avoid `ERR_EXIT`/`NO_UNSET` as a blanket header.
+
+| Bash | Zsh | Recommendation |
+|------|-----|-----------------|
+| `set -o pipefail` | `setopt PIPE_FAIL` | Keep. Pipeline exit status reflects the last non-zero stage instead of always the last stage. |
+| `set -e` | `setopt ERR_EXIT` | Avoid as a blanket header — the same unreliability caveats from `bash-pitfalls.md` apply identically to `ERR_EXIT` (doesn't fire inside a substituted condition, inside `&&`/`||` lists, or for non-final pipeline stages without `PIPE_FAIL`). Use explicit `cmd || exit`/`cmd || return` at each critical step instead. |
+| `set -u` | `setopt NO_UNSET` | Avoid as a blanket header, same reasoning as Bash's `-u` — it only catches unset-variable bugs on the exact path executed. **Caveat specific to Zsh**: ShellCheck's `--shell=bash` approximation is weaker coverage here than it is for native Bash, so lean more on manual review of variable usage in Zsh scripts than you would for Bash before concluding a script is safe without `NO_UNSET`. |
+
+**What to flag**: `setopt ERR_EXIT`/`NO_UNSET` present → Low/Medium Style
+finding recommending removal in favor of explicit checks. Any critical
+command (`cd`, destructive file ops, a deploy step) with no explicit
+exit-status check → Correctness finding regardless of `ERR_EXIT`. Missing
+`PIPE_FAIL` on a script with a meaningful pipeline → still its own
+finding.
+
+## Practical review notes
+
+- Confirm the shebang is actually `#!/usr/bin/env zsh` or `#!/bin/zsh`
+  when Zsh-only syntax (native array indexing, `(#i)` glob qualifiers,
+  `zsh/` modules, `${(f)"$(cmd)"}` parameter-expansion flags) is in use —
+  a script using Zsh-only syntax under a `sh`/`bash` shebang will fail
+  outright on systems where Zsh isn't the resolved interpreter.
+- `${(f)"$(cmd)"}`-style parameter-expansion flags are powerful
+  Zsh-specific syntax (split on newlines, join arrays, etc.) — verify they
+  aren't hiding an unquoted expansion bug underneath the flag syntax.
+- All the security guidance in `security-checklist.md` (eval, temp files,
+  credentials, least privilege, `PATH`) applies identically to Zsh — none
+  of Zsh's word-splitting differences change those risks.

--- a/plugins/dev-skills/skills/shell-script-reviewer/references/zsh-guide.md
+++ b/plugins/dev-skills/skills/shell-script-reviewer/references/zsh-guide.md
@@ -97,7 +97,7 @@ avoid `ERR_EXIT`/`NO_UNSET` as a blanket header.
 | Bash | Zsh | Recommendation |
 |------|-----|-----------------|
 | `set -o pipefail` | `setopt PIPE_FAIL` | Keep. Pipeline exit status reflects the last non-zero stage instead of always the last stage. |
-| `set -e` | `setopt ERR_EXIT` | Avoid as a blanket header — the same unreliability caveats from `bash-pitfalls.md` apply identically to `ERR_EXIT` (doesn't fire inside a substituted condition, inside `&&`/`||` lists, or for non-final pipeline stages without `PIPE_FAIL`). Use explicit `cmd || exit`/`cmd || return` at each critical step instead. |
+| `set -e` | `setopt ERR_EXIT` | Avoid as a blanket header — the same unreliability caveats from `bash-pitfalls.md` apply identically to `ERR_EXIT` (doesn't fire inside a substituted condition, inside `&&`/`\|\|` lists, or for non-final pipeline stages without `PIPE_FAIL`). Use explicit `cmd \|\| exit`/`cmd \|\| return` at each critical step instead. |
 | `set -u` | `setopt NO_UNSET` | Avoid as a blanket header, same reasoning as Bash's `-u` — it only catches unset-variable bugs on the exact path executed. **Caveat specific to Zsh**: ShellCheck's `--shell=bash` approximation is weaker coverage here than it is for native Bash, so lean more on manual review of variable usage in Zsh scripts than you would for Bash before concluding a script is safe without `NO_UNSET`. |
 
 **What to flag**: `setopt ERR_EXIT`/`NO_UNSET` present → Low/Medium Style

--- a/plugins/dev-skills/skills/shell-script-reviewer/scripts/detect_shell.sh
+++ b/plugins/dev-skills/skills/shell-script-reviewer/scripts/detect_shell.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Detect the shell dialect (bash, zsh, fish, sh/POSIX, or unknown) for a
+# script file, based on its shebang first and its extension as a fallback.
+#
+# Usage: detect_shell.sh <file>
+# Output: one word on stdout — bash | zsh | fish | sh | unknown
+
+set -o pipefail
+IFS=$'\n\t'
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <file>" >&2
+    exit 2
+fi
+
+file="$1"
+
+if [[ ! -f "$file" ]]; then
+    echo "detect_shell: no such file: $file" >&2
+    exit 2
+fi
+
+shebang=$(head -n 1 -- "$file" 2>/dev/null || true)
+
+case "$shebang" in
+    '#!'*bash*) echo "bash"; exit 0 ;;
+    '#!'*zsh*) echo "zsh"; exit 0 ;;
+    '#!'*fish*) echo "fish"; exit 0 ;;
+    '#!'*/env\ sh* | '#!'*/bin/sh) echo "sh"; exit 0 ;;
+    *) ;;
+esac
+
+case "$file" in
+    *.bash) echo "bash"; exit 0 ;;
+    *.zsh) echo "zsh"; exit 0 ;;
+    *.fish) echo "fish"; exit 0 ;;
+    *.sh)
+        # .sh with no shebang match: fall through to content sniffing below
+        # rather than guessing, since .sh is used for both bash and POSIX sh.
+        ;;
+    *) ;;
+esac
+
+# No conclusive shebang or extension: sniff for dialect-specific syntax that
+# only that shell accepts, so a plain `.sh` file with bash-only features
+# (arrays, [[, local -n) isn't misreported as POSIX sh.
+if grep -qE '(\[\[|^[[:space:]]*local -n|\bmapfile\b|\breadarray\b|\$\{[A-Za-z_][A-Za-z0-9_]*\[@\]\})' -- "$file" 2>/dev/null; then
+    echo "bash"
+    exit 0
+fi
+
+if grep -qE '^[[:space:]]*(function [A-Za-z_][A-Za-z0-9_]* )?[A-Za-z_][A-Za-z0-9_]*[[:space:]]*$' -- "$file" 2>/dev/null \
+    && grep -qE '^[[:space:]]*end[[:space:]]*$' -- "$file" 2>/dev/null; then
+    echo "fish"
+    exit 0
+fi
+
+echo "unknown"

--- a/plugins/dev-skills/skills/shell-script-reviewer/scripts/run_shellcheck.sh
+++ b/plugins/dev-skills/skills/shell-script-reviewer/scripts/run_shellcheck.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Run ShellCheck against a file with dialect-appropriate flags.
+#
+# Usage: run_shellcheck.sh <file> [bash|sh|dash|ksh] [json1|diff]
+#   dialect defaults to "bash". Zsh has no native ShellCheck dialect: callers
+#   reviewing a zsh script should pass "bash" here as a best-effort portable
+#   check and treat the result as partial coverage, not ground truth.
+#   format defaults to "json1" for programmatic parsing; pass "diff" to get
+#   a patch suitable for `| patch -p1` when applying --fix.
+
+set -o pipefail
+IFS=$'\n\t'
+
+if [[ $# -lt 1 || $# -gt 3 ]]; then
+    echo "Usage: $0 <file> [bash|sh|dash|ksh] [json1|diff]" >&2
+    exit 2
+fi
+
+file="$1"
+dialect="${2:-bash}"
+format="${3:-json1}"
+
+if [[ ! -f "$file" ]]; then
+    echo "run_shellcheck: no such file: $file" >&2
+    exit 2
+fi
+
+if ! command -v shellcheck >/dev/null 2>&1; then
+    if [[ "$format" == "diff" ]]; then
+        echo "run_shellcheck: shellcheck not installed, no diff to apply" >&2
+        exit 0
+    fi
+    echo '{"available":false,"reason":"shellcheck not installed"}'
+    exit 0
+fi
+
+# ShellCheck exits 1 when it finds issues, which is a successful run for our
+# purposes, not a failure — only exit codes >1 (usage/internal errors) mean
+# this wrapper itself failed.
+output=$(shellcheck --format="$format" --shell="$dialect" --external-sources -- "$file")
+status=$?
+
+if [[ $status -gt 1 ]]; then
+    echo "run_shellcheck: shellcheck exited with status $status" >&2
+    exit "$status"
+fi
+
+echo "$output"

--- a/plugins/dev-skills/skills/shell-script-reviewer/scripts/run_shfmt_check.sh
+++ b/plugins/dev-skills/skills/shell-script-reviewer/scripts/run_shfmt_check.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Report formatting drift for a Bash/POSIX script via `shfmt -d`, so the
+# reviewing skill can cite a concrete diff instead of prose about style.
+# Flags match this skill's adopted house style: 2-space indent, indented
+# switch cases, binary operators may start a new line, space after
+# redirect operators. Not applicable to Fish (no shfmt support) or Zsh
+# (shfmt targets bash/POSIX/mksh only and will misreport Zsh-only syntax
+# as drift).
+#
+# Usage: run_shfmt_check.sh <file>
+
+set -o pipefail
+IFS=$'\n\t'
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <file>" >&2
+    exit 2
+fi
+
+file="$1"
+
+if [[ ! -f "$file" ]]; then
+    echo "run_shfmt_check: no such file: $file" >&2
+    exit 2
+fi
+
+if ! command -v shfmt >/dev/null 2>&1; then
+    echo "shfmt not installed: skipping formatting check" >&2
+    exit 0
+fi
+
+# shfmt -d exits 1 when it produces a diff (formatting drift found) — that is
+# a successful check, not a wrapper failure. Only exit codes >1 indicate
+# shfmt itself errored (e.g. parse failure).
+diff_output=$(shfmt -d -i 2 -ci -bn -sr -- "$file")
+status=$?
+
+if [[ $status -gt 1 ]]; then
+    echo "run_shfmt_check: shfmt exited with status $status" >&2
+    exit "$status"
+fi
+
+if [[ -z "$diff_output" ]]; then
+    echo "no formatting drift"
+else
+    echo "$diff_output"
+fi


### PR DESCRIPTION
## Summary

- Adds a new `shell-script-reviewer` skill (`plugins/dev-skills/skills/shell-script-reviewer/`) that reviews Bash, Zsh, and Fish scripts for security issues, correctness/robustness bugs, portability problems, and style violations.
- Grounded in named authorities rather than ad-hoc opinion: Google Shell Style Guide, ShellCheck (codes cross-checked against shellcheck.net/wiki), Greg's Wiki BashPitfalls, and a dedicated security checklist. Fish and Zsh get their own reference files since neither is POSIX-compatible with Bash and ShellCheck doesn't (fully) cover either.
- Ships `scripts/detect_shell.sh` (dialect detection), `scripts/run_shellcheck.sh` (JSON or patch-ready diff output, used for the `--fix` flow), and `scripts/run_shfmt_check.sh` (formatting drift), plus a 13-case `evals.json` (4+ per dialect: unquoted-injection, missing error handling, unsafe `eval`, style-only).
- Registers the skill in `plugins/dev-skills/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `docs/MARKETPLACE.md`, and `plugins/dev-skills/README.md`, and adds the `.codex/skills` symlink via `make sync-codex-skills`.
- Notable design choice: the skill does **not** recommend `set -euo pipefail` ("unofficial Bash strict mode") as a best practice. It flags `-e`/`-u` (and Zsh's `ERR_EXIT`/`NO_UNSET`) as a maintainability anti-pattern when present, keeps `pipefail`, and requires explicit per-command exit-status checks instead — see `references/bash-pitfalls.md` for the reasoning. This policy came directly from an internal shell-scripting-standards document provided during review, not from the initial draft.

## Test plan

- [x] `make test` — 65/65 passed, plus Codex skill-symlink check
- [x] `make sync-codex-skills` — symlink created and in sync
- [x] Downloaded a real ShellCheck binary and ran it against all bash eval cases, confirming expected SC codes fire (SC2164, SC2086, SC2006) and confirming the `eval`-injection cases produce no ShellCheck output (by design — that's what the manual security review step exists to catch)
- [x] Ran ShellCheck (with project `.shellcheckrc`) against the skill's own wrapper scripts — clean
- [x] Verified the `run_shellcheck.sh ... diff | patch -p1` autofix path applies cleanly and fixes the flagged issue
- [x] Cross-checked all cited ShellCheck codes and Fish semantics against shellcheck.net/wiki and fishshell.com docs live, rather than from memory

---

Built with [Claude Code](https://claude.com/claude-code) in collaboration with @rikdc, who supplied review direction, decisions (including the strict-mode policy above), and several shell-scripting-standards references that shaped the final design.